### PR TITLE
Extend test coverage to cover CalloutExceptions and non-200 HTTP responses

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,8 +48,8 @@ Configuration
 
 In addition to bringing the source code into the Sandbox environment, the system need to be configured appropriately to allow the HTTP calls to go through.  Create a ``Remote Site`` by traversing ``Security Controls`` > ``Remote Site Settings`` and use these values:
 
-  :Remote Site Name: PokitDok_Platform
-  :Remote Site URL: https://platform.pokitdok.com
+:Remote Site Name: PokitDok_Platform
+:Remote Site URL: https://platform.pokitdok.com
   
 
 Testing

--- a/example/Eligibility.apxc
+++ b/example/Eligibility.apxc
@@ -13,10 +13,18 @@
  * 
  * The Client ID and Client Secret credentials passed into the API Client constructor are
  * obtained by signing up for free at https://platform.pokitdok.com.
+ * 
+ * Copyright (C) 2016, All Rights Reserved, PokitDok, Inc.
+ * https://platform.pokitdok.com
+ *
+ * Please see the License.txt file for more information.
+ * All other rights reserved.
  */
 global with sharing class Eligibility {    
-    static final String CLIENT_ID = '<YOUR_CLIENT_ID>';
-    static final String CLIENT_SECRET = '<YOUR_CLIENT_SECRET>';
+ 
+    // These are your credentials
+    static final String CLIENT_ID = 'bbVYgUxvBfN7vro7viOT';
+    static final String CLIENT_SECRET = 'lSVEDN1y9nonyGepW13PnbCBcOReiS5fTEVXMN4g';
     
     /**
      * The runEligibilityCheck() method instantiates the API Client, manufactures a JSON

--- a/example/Eligibility.apxc
+++ b/example/Eligibility.apxc
@@ -23,8 +23,8 @@
 global with sharing class Eligibility {    
  
     // These are your credentials
-    static final String CLIENT_ID = 'bbVYgUxvBfN7vro7viOT';
-    static final String CLIENT_SECRET = 'lSVEDN1y9nonyGepW13PnbCBcOReiS5fTEVXMN4g';
+    static final String CLIENT_ID = '<YOUR_CLIENT_ID>';
+    static final String CLIENT_SECRET = '<YOUR_CLIENT_SECRET>';
     
     /**
      * The runEligibilityCheck() method instantiates the API Client, manufactures a JSON

--- a/src/PokitDokAPIClient.apxc
+++ b/src/PokitDokAPIClient.apxc
@@ -14,8 +14,15 @@
  * The endpoint for https://platform.pokitdok.com needs to be set up as a Remote Site.
  * For reference, see:
  * https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_callouts_remote_site_settings.htm
+ * 
+ * Copyright (C) 2016, All Rights Reserved, PokitDok, Inc.
+ * https://platform.pokitdok.com
+ *
+ * Please see the License.txt file for more information.
+ * All other rights reserved.
  */
 public class PokitDokAPIClient {   
+    
     // URL endpoints
     public static final String POKITDOK_BASE_URL = 'https://platform.pokitdok.com';
     public static final String AUTHENTICATION_ENDPOINT = '/oauth2/token';

--- a/src/PokitDokAPIClient.apxc
+++ b/src/PokitDokAPIClient.apxc
@@ -21,6 +21,9 @@ public class PokitDokAPIClient {
     public static final String AUTHENTICATION_ENDPOINT = '/oauth2/token';
     public static final String ELIGIBILITY_ENDPOINT = '/api/v4/eligibility/';
     
+    public static final String CALLOUT_EXCEPTION_MESSAGE = 'Unable to process your ' +
+        'request at this time. The original request has been logged';
+    
     // The OAuth credentials
     private String clientID;
     private String clientSecret;
@@ -118,8 +121,7 @@ public class PokitDokAPIClient {
                              '[PokitDokAPIClient]  Error Message: ' + e);
                 System.debug(Logginglevel.ERROR, 
                              '[PokitDokAPIClient]  POST Request: ' + request.getBody());
-                return '{ "error": "Unable to process your eligibility at this time.  ' + 
-                    'The origianl request has been logged" }';
+                return '{ "error": ' + CALLOUT_EXCEPTION_MESSAGE + ' }';
             }
             
             // Log bad responses

--- a/test/PokitDokAPIClientTest.apxc
+++ b/test/PokitDokAPIClientTest.apxc
@@ -3,6 +3,12 @@
  * Platform.  Since APEX test classes are not permitted to access remote sites, the
  * responses from the method calls are all mocked.  The mocked responses are produced
  * by the PokitDokMockResponseGenerator.
+ * 
+ * Copyright (C) 2016, All Rights Reserved, PokitDok, Inc.
+ * https://platform.pokitdok.com
+ *
+ * Please see the License.txt file for more information.
+ * All other rights reserved.
  */
 @isTest
 public class PokitDokAPIClientTest {

--- a/test/PokitDokAPIClientTest.apxc
+++ b/test/PokitDokAPIClientTest.apxc
@@ -6,7 +6,7 @@
  */
 @isTest
 public class PokitDokAPIClientTest {
-    
+   
     /**
      * The testAuthentication method tests that the access token is on the response.
      * Since this test does not actually go across the wire, thge actual Client ID /
@@ -15,7 +15,7 @@ public class PokitDokAPIClientTest {
     @isTest 
     static void testAuthentication() {
         // Set mock callout class 
-        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator());        
+        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator(false, false));        
         PokitDokAPIClient pokitDok = new PokitDokAPIClient('clientID', 'clientSecret');
         String session_token = pokitDok.authenticate();
         
@@ -46,7 +46,7 @@ public class PokitDokAPIClientTest {
      */    
     @isTest static void testEligibility() {
         // Set mock callout class 
-        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator());        
+        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator(false, false));        
         PokitDokAPIClient pokitDok = new PokitDokAPIClient('clientId', 'clientSecret');
         
         // Create a test JSON request
@@ -92,4 +92,66 @@ public class PokitDokAPIClientTest {
             }
         }        
     }
+
+    /**
+     * The testUnsuccessfulResponse method tests an HTTP response with a status code
+     * other than 200.  The client will simply return the error message it received
+     * from the APIs.  The message will include a JSON field called "errors".
+     */
+    @isTest 
+    static void testUnsuccessfulResponse() {
+        // Set mock callout class 
+        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator(false, true));        
+        PokitDokAPIClient pokitDok = new PokitDokAPIClient('clientID', 'clientSecret');
+
+        // Create an empty test JSON request
+        Map<String,Object> eligibilityRequest = new Map<String,Object>();
+        String eligibilityResponse = pokitDok.eligibility(JSON.serialize(eligibilityRequest));
+        
+        // Verify there is an error message in the JSON response
+        System.assert(eligibilityResponse != null);
+        String expectedUnsuccessfulMessage = '';
+        
+        JSONParser parser = JSON.createParser(eligibilityResponse);
+        while (parser.nextToken() != null) {
+            if ((parser.getCurrentToken() == JSONToken.FIELD_NAME) && 
+                (parser.getText() == 'errors')) {
+                parser.nextToken();
+                expectedUnsuccessfulMessage = parser.getText();
+                System.assertEquals(expectedUnsuccessfulMessage, 
+                                    PokitDokMockResponseGenerator.UNSUCCESSFUL_MESSAGE);
+            }
+        }
+    }
+    
+    /**
+     * The testCalloutException method tests a borked HTTP connection.  The client 
+     * will return a manufactured JSON message will include a JSON field called 
+     * "error".
+     */
+    @isTest 
+    static void testCalloutException() {
+        // Set mock callout class 
+        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator(true, false));        
+        PokitDokAPIClient pokitDok = new PokitDokAPIClient('clientID', 'clientSecret');
+
+        // Create an empty test JSON request
+        Map<String,Object> eligibilityRequest = new Map<String,Object>();
+        String eligibilityResponse = pokitDok.eligibility(JSON.serialize(eligibilityRequest));
+        
+        // Verify there is an error message in the JSON response
+        System.assert(eligibilityResponse != null);
+        String expectedCalloutExceptionMessage = '';
+        
+        JSONParser parser = JSON.createParser(eligibilityResponse);
+        while (parser.nextToken() != null) {
+            if ((parser.getCurrentToken() == JSONToken.FIELD_NAME) && 
+                (parser.getText() == 'error')) {
+                parser.nextToken();
+                expectedCalloutExceptionMessage = parser.getText();
+                System.assertEquals(expectedCalloutExceptionMessage, 
+                                    PokitDokAPIClient.CALLOUT_EXCEPTION_MESSAGE);
+            }
+        }
+    }    
 }

--- a/test/PokitDokMockResponseGenerator.apxc
+++ b/test/PokitDokMockResponseGenerator.apxc
@@ -3,20 +3,25 @@
  * calls need to be mocked.  The PokitDokMockResponseGenerator class implements the 
  * HttpCalloutMock interface and generate fake HTTPResponses for the various endpoints
  * of the PokitDok Platform.
+ * 
+ * Copyright (C) 2016, All Rights Reserved, PokitDok, Inc.
+ * https://platform.pokitdok.com
+ *
+ * Please see the License.txt file for more information.
+ * All other rights reserved.
  */
 @isTest
 public class PokitDokMockResponseGenerator implements HttpCalloutMock {
+    
     // Test constants
     public final static String ACCESS_TOKEN = 'POKIT_TOKEN';
     public final static String ACTIVITY_ID = '11111111';
     public final static String CORRELATION_ID = '99999999';
     public final static String UNSUCCESSFUL_MESSAGE = 'Unprocessable Entity';
-    public final static String CALLOUT_EXCEPTION_MESSAGE = 'Unable to process...';
     
     // Configures whether or not to handle error conditions
     public boolean isExceptionThrown = false;
     public boolean isResponseUnsuccessful = false;
-    
     
     /**
      * The constructor allows the calling test code to configure the mock response
@@ -45,14 +50,13 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
             throw e;   
         }
         
-        HttpResponse response = new HttpResponse();
-        
         // Create a mocked response for testing an unsuccessful response
         if (isResponseUnsuccessful) {
             return createUnsuccessfulResponse();   
         }
         
         // Create a mocked response for testing authentication
+        HttpResponse response = new HttpResponse();
         if (request.getEndpoint() == PokitDokAPIClient.POKITDOK_BASE_URL + 
                                      PokitDokAPIClient.AUTHENTICATION_ENDPOINT) {                                         
             response = createAuthenticationResponse();

--- a/test/PokitDokMockResponseGenerator.apxc
+++ b/test/PokitDokMockResponseGenerator.apxc
@@ -10,6 +10,23 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
     public final static String ACCESS_TOKEN = 'POKIT_TOKEN';
     public final static String ACTIVITY_ID = '11111111';
     public final static String CORRELATION_ID = '99999999';
+    public final static String UNSUCCESSFUL_MESSAGE = 'Unprocessable Entity';
+    public final static String CALLOUT_EXCEPTION_MESSAGE = 'Unable to process...';
+    
+    // Configures whether or not to handle error conditions
+    public boolean isExceptionThrown = false;
+    public boolean isResponseUnsuccessful = false;
+    
+    
+    /**
+     * The constructor allows the calling test code to configure the mock response
+     * generator to handle error conditions.
+     */
+    public PokitDokMockResponseGenerator(boolean isExceptionThrown, 
+                                         boolean isResponseUnsuccessful) {
+        isExceptionThrown = isExceptionThrown;
+		isResponseUnsuccessful = isResponseUnsuccessful;
+    }
     
     /**
      * The respond method returns a mocked HTTPResponse that can be tested by assertion.
@@ -21,22 +38,34 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
      * @return a mocked HTTPResponse
      */
     public HTTPResponse respond(HTTPRequest request) {
+        // Throw an exception for testing an HTTP error
+        if (isExceptionThrown) {
+            CalloutException e = (CalloutException)CalloutException.class.newInstance();
+            e.setMessage('Mock CalloutException thrown.');
+            throw e;   
+        }
+        
         HttpResponse response = new HttpResponse();
+        
+        // Create a mocked response for testing an unsuccessful response
+        if (isResponseUnsuccessful) {
+            return createUnsuccessfulResponse();   
+        }
         
         // Create a mocked response for testing authentication
         if (request.getEndpoint() == PokitDokAPIClient.POKITDOK_BASE_URL + 
-            						 PokitDokAPIClient.AUTHENTICATION_ENDPOINT) {
-			response = createAuthenticationResponse();
+                                     PokitDokAPIClient.AUTHENTICATION_ENDPOINT) {                                         
+            response = createAuthenticationResponse();
         }
         
         // Create a mocked response for testing an eligibility request
         if (request.getEndpoint() == PokitDokAPIClient.POKITDOK_BASE_URL + 
-            						 PokitDokAPIClient.ELIGIBILITY_ENDPOINT) {
-			response = createEligibilityResponse();
+                                     PokitDokAPIClient.ELIGIBILITY_ENDPOINT) {			
+            response = createEligibilityResponse();            
         }
         return response;
     }
-
+    
     /**
      * The createAuthenticationResponse method creates a mocked HTTPResponse to the
      * authentication endpoint.  Namely it creates a fake OAuth access token to be
@@ -73,7 +102,7 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
         
         Map<String,Object> eligibilityResponse = new Map<String,Object>();
         
-		Map<String,Object> meta = new Map<String,Object>();
+        Map<String,Object> meta = new Map<String,Object>();
         meta.put('activity_id', ACTIVITY_ID);
         eligibilityResponse.put('meta', meta);
         
@@ -82,6 +111,26 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
         eligibilityResponse.put('data', data);    
         
         response.setBody(JSON.serialize(eligibilityResponse));
+        return response;
+    }
+
+    /**
+     * The createUnsuccessfulResponse method creates a mocked HTTPResponse to an 
+     * API endpoint.  It returns a status code of 422, however, to exercise a failure
+     * case.
+     * 
+     * @return the HTTPResponse with a 422 status code
+     */
+    private HTTPResponse createUnsuccessfulResponse() {
+        // Create a fake unsuccessful authentication response
+        HttpResponse response = new HttpResponse();
+		response.setStatusCode(422);
+        response.setHeader('Content-Type', 'application/json');
+
+        Map<String,Object> authenticationResponse = new Map<String,Object>();
+        authenticationResponse.put('errors', UNSUCCESSFUL_MESSAGE);       
+        response.setBody(JSON.serialize(authenticationResponse));
+        
         return response;
     }
 }


### PR DESCRIPTION
Added more test coverage for unsuccessful responses and exception cases.  Added the ability of the PokitDokMockResponseGenerator to be configured to change its responses based on two new flags:  `isExceptionThrown` and `isResponseUnsuccessful`.

Added copyright / license comments.