### PR TITLE
PLATFORM-5041: Implement session access token caching

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,34 @@ Create a new ``Remote Site`` with these values:
 Reference the APEX Developer's Guide for additional information about adding a `Remote Site <https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_callouts_remote_site_settings.htm>`_.
 
 
+Platform Cache
+--------------
+
+OAuth session access tokens can be persisted and used across the organization to eliminate the need to authenticate with the PokitDok Platform servers with each API request.  This is accomplished by utilizing the Salesforce Platform Cache.
+
+The Salesforce Platform Cache lets you store and retrieve data that is shared across your organization. Put, retrieve, or remove cache values by using the Cache.Org and Org.Partition classes in the Cache namespace. Use the Platform Cache Partition tool to create or remove org partitions and allocate their cache capacities to balance performance across apps.
+
+Unlike session cache, org cache is accessible across sessions, requests, and org users and profiles. Org cache expires when its specified time-to-live is reached, in this case, 60 minutes.
+
+If your organization has not set up a default cache partition by following these steps.
+
+Navigate: ``Setup`` > ``Platform Cache`` > ``New Platform Cache Partition``
+
+Create a default cache with these or similar configuration parameters.
+
+*Details*
+
+:Label: BaseOrgCachePartition
+:Name: BaseOrgCachePartition
+:Default Partition: X
+:Description: Default Org level cache partition
+
+*Org Cache Allocation*
+
+:Organization: 5
+
+Reference the APEX Developer's Guide for additional information about configuring `Platform Cache <https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_cache_namespace_overview.htm>`_.
+
 Testing
 -------
 
@@ -79,4 +107,3 @@ Copyright (c) 2016 PokitDok, Inc.  See LICENSE_ for details.
 .. _issues: https://github.com/pokitdok/pokitdok-apex/issues
 .. _example: https://github.com/pokitdok/pokitdok-apex/tree/dev/example
 .. _LICENSE: LICENSE.txt
-

--- a/example/Eligibility.apxc
+++ b/example/Eligibility.apxc
@@ -24,8 +24,8 @@
 global with sharing class Eligibility {    
  
     // These are your credentials
-    static final String CLIENT_ID = 'bbVYgUxvBfN7vro7viOT';
-    static final String CLIENT_SECRET = 'lSVEDN1y9nonyGepW13PnbCBcOReiS5fTEVXMN4g';
+    static final String CLIENT_ID = '<YOUR_CLIENT_ID>';
+    static final String CLIENT_SECRET = '<YOUR_CLIENT_SECRET>';    
     
     /**
      * The runEligibilityCheck() method instantiates the API Client, manufactures a JSON

--- a/example/Eligibility.apxc
+++ b/example/Eligibility.apxc
@@ -24,8 +24,8 @@
 global with sharing class Eligibility {    
  
     // These are your credentials
-    static final String CLIENT_ID = '<YOUR_CLIENT_ID>';
-    static final String CLIENT_SECRET = '<YOUR_CLIENT_SECRET>';
+    static final String CLIENT_ID = 'bbVYgUxvBfN7vro7viOT';
+    static final String CLIENT_SECRET = 'lSVEDN1y9nonyGepW13PnbCBcOReiS5fTEVXMN4g';
     
     /**
      * The runEligibilityCheck() method instantiates the API Client, manufactures a JSON
@@ -35,9 +35,10 @@ global with sharing class Eligibility {
     webservice static String runEligibilityCheck(String patientID) {
         
         // Use the PokitDok API Client to make an eligibility request
-        PokitDokAPIClient pokitdok = new PokitDokAPIClient(CLIENT_ID, CLIENT_SECRET);
+        PokitDokAPIClient pokitdok = new PokitDokAPIClient(CLIENT_ID, CLIENT_SECRET, true);
         String eligibilityRequest = buildEligibilityRequest(patientID);
         String eligibilityResponse = pokitdok.eligibility(eligibilityRequest);
+        //System.debug('[Eligibility]  autoRenewSession: ' + pokitdok.autoRenewSession);
         
         // Check for errors
         String errorMessage = null;
@@ -135,7 +136,7 @@ global with sharing class Eligibility {
                               where Name = :patientID];
         
         String meaningfulResponse = '';
-        boolean isActive = false;
+        Boolean isActive = false;
         Date planBeginDate = null;
         
         // Parse the response, extracting the active flag and the date that plan coverage
@@ -170,3 +171,4 @@ global with sharing class Eligibility {
         return meaningfulResponse;
     }  
 }
+

--- a/example/Eligibility.apxc
+++ b/example/Eligibility.apxc
@@ -25,7 +25,7 @@ global with sharing class Eligibility {
  
     // These are your credentials
     static final String CLIENT_ID = '<YOUR_CLIENT_ID>';
-    static final String CLIENT_SECRET = '<YOUR_CLIENT_SECRET>';    
+    static final String CLIENT_SECRET = '<YOUR_CLIENT_SECRET>';
     
     /**
      * The runEligibilityCheck() method instantiates the API Client, manufactures a JSON
@@ -38,7 +38,6 @@ global with sharing class Eligibility {
         PokitDokAPIClient pokitdok = new PokitDokAPIClient(CLIENT_ID, CLIENT_SECRET, true);
         String eligibilityRequest = buildEligibilityRequest(patientID);
         String eligibilityResponse = pokitdok.eligibility(eligibilityRequest);
-        //System.debug('[Eligibility]  autoRenewSession: ' + pokitdok.autoRenewSession);
         
         // Check for errors
         String errorMessage = null;

--- a/src/PokitDokAPIClient.apxc
+++ b/src/PokitDokAPIClient.apxc
@@ -21,7 +21,7 @@
  * Please see the License.txt file for more information.
  * All other rights reserved.
  */
-public class PokitDokAPIClient {   
+public class PokitDokAPIClient {
     
     // URL endpoints
     public static final String POKITDOK_BASE_URL = 'https://platform.pokitdok.com';
@@ -31,9 +31,11 @@ public class PokitDokAPIClient {
     public static final String CALLOUT_EXCEPTION_MESSAGE = 'Unable to process your ' +
         'request at this time. The original request has been logged';
     
-    // The OAuth credentials
+    // Session management
     private String clientID;
     private String clientSecret;
+    public Boolean autoRenewSession { get; set; }
+    public PokitDokSessionCacheManager sessionManager = null;
     
     /**
      * The constructor expects valid OAuth credentials.
@@ -41,22 +43,58 @@ public class PokitDokAPIClient {
      * @param the id is Client ID for the PokitDok Platform App
      * @param the secret is Client Secret for the PokitDok Platform App
      */
-    public PokitDokAPIClient(String id, String secret) {
-        clientID = id;
-        clientSecret = secret;
+    public PokitDokAPIClient(String clientID, String clientSecret) {
+        this.clientID = clientID;
+        this.clientSecret = clientSecret;
+        this.autoRenewSession = false;
+    }
+
+    /**
+     * The constructor expects valid OAuth credentials and a flag to determine if the
+     * access token should be cached and renewed when it expires.
+     * 
+     * @param the id is Client ID for the PokitDok Platform App
+     * @param the secret is Client Secret for the PokitDok Platform App
+     * @param should the session access token be cached and the session be renewed
+     *        after the token expires
+     */
+    public PokitDokAPIClient(String clientID, String clientSecret, Boolean autoRenewSession) {
+        this.clientID = clientID;
+        this.clientSecret = clientSecret;
+        this.autoRenewSession = autoRenewSession;
+        
+        if (autoRenewSession) {
+            sessionManager = new PokitDokSessionCacheManager(clientID);
+
+            // Make sure the Platform Cache is set up properly
+            if (!sessionManager.cacheEnabled) {
+                this.autoRenewSession = false;
+            }
+        }
     }
     
     /**
      * The authenticate method encapsulates OAuth requests and returns the session access
      * token to be used by subsequent API calls.
      * 
-     * Note:  The present version will retrieve a fresh access token for every API request.
-     * Future versions will cache the access token in local storage for usage.  If the 
-     * status code of the API call is 401, only then will the access token be requested.
+     * Authentication works one of two ways.  You can exercise the option to utilize the
+     * Salesforce Platform Cache to store the session access token for future requests,
+     * or you can authenticate with each request.  Caching is preferred if possible.
      * 
-     * @return the access token if authenticated; an empty String otherwise
+     * @return the session access token if authenticated; an empty String otherwise
      */
     public String authenticate() {
+        String accessToken = '';
+        
+        // Check the cache for the access token
+        if (autoRenewSession) {
+            accessToken = sessionManager.getToken();
+            if (accessToken != null) {
+                return accessToken;
+            }
+        }
+        
+        // Retrieve the access token
         Http http = new Http();
         HttpRequest request = new HttpRequest();
         HTTPResponse response = new HttpResponse();
@@ -79,10 +117,8 @@ public class PokitDokAPIClient {
         try {
             response = http.send(request);
         } catch(System.CalloutException e) {
-            System.debug(Logginglevel.ERROR, 
-                         '[PokitDokAPIClient]  Error Message: ' + e);
-            System.debug(Logginglevel.ERROR, 
-                         '[PokitDokAPIClient]  POST Request: ' + request.getBody());
+            processCalloutException(e, request);
+            return '';
         }
         
         // Dig out the access token from the response payload
@@ -90,12 +126,18 @@ public class PokitDokAPIClient {
         while (parser.nextToken() != null) {
             if ((parser.getCurrentToken() == JSONToken.FIELD_NAME) && 
                 (parser.getText() == 'access_token')) {
-                    parser.nextToken();
-                    String sessionToken = parser.getText();
-                    return sessionToken;                    
+                parser.nextToken();
+                accessToken = parser.getText();
+
+                // Cache the token for future requests
+                if (autoRenewSession) {
+                    sessionManager.putToken(accessToken);
                 }
+                
+                return accessToken;                    
+            }
         }
-        
+                
         return '';
     }
     
@@ -112,26 +154,38 @@ public class PokitDokAPIClient {
         HTTPResponse response = new HttpResponse();
         
         // Authenticate before making the API call
-        String sessionToken = authenticate();        
-        if (sessionToken != '') {
+        String accessToken = authenticate();        
+        if (accessToken != '') {
             // Set up the request to the PokitDok Platform POST endpoint
             request.setEndpoint(APIEndpoint);
             request.setMethod('POST');
-            request.setHeader('Authorization', 'Bearer ' + sessionToken);
+            request.setHeader('Authorization', 'Bearer ' + accessToken);
             request.setHeader('Content-Type', 'application/json');
             request.setBody(requestPayload);
             
             try {
                 response = http.send(request);
             } catch(System.CalloutException e) {
-                System.debug(Logginglevel.ERROR, 
-                             '[PokitDokAPIClient]  Error Message: ' + e);
-                System.debug(Logginglevel.ERROR, 
-                             '[PokitDokAPIClient]  POST Request: ' + request.getBody());
-                return '{ "error": ' + CALLOUT_EXCEPTION_MESSAGE + ' }';
+                return processCalloutException(e, request);
             }
             
-            // Log bad responses
+            // If the session has expired, flush the cache, renew the access token and
+            // replay the transaction
+            if (response.getStatusCode() == 401) {
+                if (sessionManager.removeToken()) {
+                    accessToken = authenticate();
+                    if (accessToken != '') {
+                        request.setHeader('Authorization', 'Bearer ' + accessToken);
+                        try {
+                            response = http.send(request);
+                        } catch(System.CalloutException e) {
+                            return processCalloutException(e, request);
+                        }
+                    }
+                }
+            }
+            
+            // Log bad responses            
             if (response.getStatusCode() != 200) {
                 System.debug(Logginglevel.ERROR, 
                              '[PokitDokAPIClient]  POST Request: ' + request.getBody());
@@ -155,4 +209,22 @@ public class PokitDokAPIClient {
         String endpoint = POKITDOK_BASE_URL + ELIGIBILITY_ENDPOINT;
         return post(endpoint, serializedJSON);
     }
+    
+    /**
+     * The processCalloutException method handles the event of a CalloutException being
+     * thrown.  It spools out the exception message to the error log
+     * 
+     * @param the thrown CalloutException
+     * @param the request that caused the exception to be thrown
+     * @return the error message to be consumed programatically
+     */
+    private String processCalloutException(System.CalloutException e, 
+                                           HTTPRequest request) {
+        System.debug(Logginglevel.ERROR, 
+                     '[PokitDokAPIClient.processCalloutException]  Error Message: ' + e);
+        System.debug(Logginglevel.ERROR, 
+                     '[PokitDokAPIClient.processCalloutException]  POST Request: ' + request.getBody());
+        return '{ "error": ' + CALLOUT_EXCEPTION_MESSAGE + ' }';        
+    }
 }
+

--- a/src/PokitDokAPIClient.apxc
+++ b/src/PokitDokAPIClient.apxc
@@ -137,7 +137,7 @@ public class PokitDokAPIClient {
                 return accessToken;                    
             }
         }
-                
+
         return '';
     }
     

--- a/src/PokitDokSessionCacheManager.apxc
+++ b/src/PokitDokSessionCacheManager.apxc
@@ -1,0 +1,111 @@
+/**
+ * The PokitDokSessionCacheManager class manages the storage and retrieval of
+ * the OAuth access token for session management with the PokitDok Platform.
+ * It employs the Salesforce Platform Cache, a new feature available to 
+ * Enterprise, Unlimited, and Performance editions.  This Cache Manager uses
+ * the Org Cache which allows for the storage of the session access token for
+ * users across the organization.
+ *
+ * For more information, see: https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_cache_namespace_overview.htm
+ * 
+ * Copyright (C) 2016, All Rights Reserved, PokitDok, Inc.
+ * https://platform.pokitdok.com
+ *
+ * Please see the License.txt file for more information.
+ * All other rights reserved.
+ */
+public class PokitDokSessionCacheManager {
+    
+    // The PokitDok Platform session is only alive for an hour, so set the
+    // cache time to live appropriately
+    private final integer TIME_TO_LIVE = 3600;
+    
+    // A flag for calling code to determine if the Platform Cache is available
+    // for usage
+    public Boolean cacheEnabled { get; set; }
+    
+    // The default cache partition
+    private Cache.OrgPartition cachePartition = null;
+        
+    // The cache key: 'PokitDokAccessToken' + clientID
+    private String accessTokenCacheKey;
+        
+    /**
+     * The constructor takes in the Client ID.  This allows organizations that
+     * have multiple PokitDok Platform Apps to each store their own session access
+     * token in the cache.
+     *
+     * @param the Client ID of the PokitDok Platform App.
+     */
+    public PokitDokSessionCacheManager(String clientID) {
+        this.cacheEnabled = false;
+        
+        // See if a cache partition is available.  If it is, set the flag and define
+        // the cache key
+        String defaultPartition = Cache.Org.getName();
+        if (defaultPartition != '') {
+            cacheEnabled = true;
+            cachePartition = Cache.Org.getPartition(defaultPartition);
+            accessTokenCacheKey = 'PokitDokAccessToken' + clientID;
+        }
+    }
+
+    /**
+     * The getCacheStatistics method provides some diagnostics around the cache.
+     * This feature is apparently new in Salesforce and this data might be useful
+     * to inspect.
+     * 
+     * @return a map of data about the state of the cache
+     */
+    public Map<String, Object> getCacheStatistics() {
+        Map<String, Object> cacheStatistics = new Map<String, Object>();
+        cacheStatistics.put('default_partition', Cache.Org.getName());
+    	cacheStatistics.put('capacity', Cache.Org.getCapacity());
+        cacheStatistics.put('number_of_keys', Cache.Org.getNumKeys());
+        cacheStatistics.put('keys', Cache.Org.getKeys());
+        cacheStatistics.put('miss_rate', Cache.Org.getMissRate());
+        cacheStatistics.put('average_get_time', Cache.Org.getAvgGetTime());
+        cacheStatistics.put('max_get_time', Cache.Org.getMaxGetTime());
+        return cacheStatistics;
+    }
+    
+    /**
+     * The getToken method abstracts the retrieval of the session access token.
+     * 
+     * @return the token from cache if available
+     */
+    public String getToken() {
+        if (!cacheEnabled) {
+            return null;
+        }
+                
+        return (String) cachePartition.get(accessTokenCacheKey);
+    }
+
+    /**
+     * The putToken method abstracts the storage of the session access token.
+     * 
+     * @param the value of the session access token to cache
+     */
+    public void putToken(String value) {
+        if (!cacheEnabled) {
+            return;
+        }
+
+        cachePartition.put(accessTokenCacheKey, value, TIME_TO_LIVE, Cache.Visibility.ALL, false);
+    }
+
+    /**
+     * The removeToken method abstracts the removal of the session access token.
+     *
+     * @return if the removal was successful
+     */
+    public Boolean removeToken() {
+        if (!cacheEnabled) {
+            return false;
+        }
+        
+        return cachePartition.remove(accessTokenCacheKey);        
+    }
+}
+

--- a/src/PokitDokSessionCacheManager.apxc
+++ b/src/PokitDokSessionCacheManager.apxc
@@ -60,7 +60,7 @@ public class PokitDokSessionCacheManager {
     public Map<String, Object> getCacheStatistics() {
         Map<String, Object> cacheStatistics = new Map<String, Object>();
         cacheStatistics.put('default_partition', Cache.Org.getName());
-    	cacheStatistics.put('capacity', Cache.Org.getCapacity());
+        cacheStatistics.put('capacity', Cache.Org.getCapacity());
         cacheStatistics.put('number_of_keys', Cache.Org.getNumKeys());
         cacheStatistics.put('keys', Cache.Org.getKeys());
         cacheStatistics.put('miss_rate', Cache.Org.getMissRate());

--- a/test/PokitDokAPIClientTest.apxc
+++ b/test/PokitDokAPIClientTest.apxc
@@ -13,6 +13,31 @@
 @isTest
 public class PokitDokAPIClientTest {
    
+    public final static String TEST_CLIENT_ID = 'ClientID';
+    public final static String TEST_CLIENT_SECRET = 'ClientSecret';
+    
+    /**
+     * The testAutoRenewalSetting method tests how the autoRenewSession flag is set in
+     * the constructors. 
+     */
+    @isTest 
+    static void testAutoRenewalSetting() {
+        // Verify the Platform Cache Partition won't be used
+        PokitDokAPIClient pokitDok = new PokitDokAPIClient(TEST_CLIENT_ID, TEST_CLIENT_SECRET);
+        Boolean autoRenewSession = pokitDok.autoRenewSession;        
+        System.assertEquals(autoRenewSession, false);
+        
+        pokitDok = new PokitDokAPIClient(TEST_CLIENT_ID, TEST_CLIENT_SECRET, false);
+        autoRenewSession = pokitDok.autoRenewSession;
+        System.assertEquals(autoRenewSession, false);
+        
+        // Verify the Platform Cache Partition will be used
+        pokitDok = new PokitDokAPIClient(TEST_CLIENT_ID, TEST_CLIENT_SECRET, true);
+        autoRenewSession = pokitDok.autoRenewSession;        
+        System.assertEquals(autoRenewSession, true);
+    }
+    
+    
     /**
      * The testAuthentication method tests that the access token is on the response.
      * Since this test does not actually go across the wire, thge actual Client ID /
@@ -21,9 +46,12 @@ public class PokitDokAPIClientTest {
     @isTest 
     static void testAuthentication() {
         // Set mock callout class 
-        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator(false, false));        
-        PokitDokAPIClient pokitDok = new PokitDokAPIClient('clientID', 'clientSecret');
+        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator(false, false, 
+                                                                              false));
+        PokitDokAPIClient pokitDok = new PokitDokAPIClient(TEST_CLIENT_ID, TEST_CLIENT_SECRET, 
+                                                           true);
         String session_token = pokitDok.authenticate();
+        session_token = pokitDok.authenticate();
         
         // Verify the session access token has been set
         System.assertEquals(session_token, PokitDokMockResponseGenerator.ACCESS_TOKEN);
@@ -52,8 +80,10 @@ public class PokitDokAPIClientTest {
      */    
     @isTest static void testEligibility() {
         // Set mock callout class 
-        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator(false, false));        
-        PokitDokAPIClient pokitDok = new PokitDokAPIClient('clientId', 'clientSecret');
+        Test.setMock(HttpCalloutMock.class, 
+                     new PokitDokMockResponseGenerator(false, false, false));        
+        PokitDokAPIClient pokitDok = new PokitDokAPIClient(TEST_CLIENT_ID, TEST_CLIENT_SECRET, 
+                                                           true);
         
         // Create a test JSON request
         Map<String,Object> eligibilityRequest = new Map<String,Object>();
@@ -100,15 +130,50 @@ public class PokitDokAPIClientTest {
     }
 
     /**
+     * The testCalloutException method tests a borked HTTP connection.  The client 
+     * will return a manufactured JSON message will include a JSON field called 
+     * "error".
+     */
+    @isTest 
+    static void testCalloutException() {
+        // Set mock callout class 
+        Test.setMock(HttpCalloutMock.class, 
+                     new PokitDokMockResponseGenerator(true, false, false));        
+        PokitDokAPIClient pokitDok = new PokitDokAPIClient(TEST_CLIENT_ID, TEST_CLIENT_SECRET, 
+                                                           false);        
+
+        // Create an empty test JSON request
+        Map<String,Object> eligibilityRequest = new Map<String,Object>();
+        String eligibilityResponse = pokitDok.eligibility(JSON.serialize(eligibilityRequest));
+        
+        // Verify there is an error message in the JSON response
+        System.assert(eligibilityResponse != null);
+        String expectedCalloutExceptionMessage = '';
+        
+        JSONParser parser = JSON.createParser(eligibilityResponse);
+        while (parser.nextToken() != null) {
+            if ((parser.getCurrentToken() == JSONToken.FIELD_NAME) && 
+                (parser.getText() == 'error')) {
+                parser.nextToken();
+                expectedCalloutExceptionMessage = parser.getText();
+                System.assertEquals(expectedCalloutExceptionMessage, 
+                                    PokitDokAPIClient.CALLOUT_EXCEPTION_MESSAGE);
+            }
+        }
+    }
+    
+    /**
      * The testUnsuccessfulResponse method tests an HTTP response with a status code
-     * other than 200.  The client will simply return the error message it received
-     * from the APIs.  The message will include a JSON field called "errors".
+     * other than 200 and 401.  The client will simply return the error message it
+     * received from the APIs.  The message will include a JSON field called "errors".
      */
     @isTest 
     static void testUnsuccessfulResponse() {
         // Set mock callout class 
-        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator(false, true));        
-        PokitDokAPIClient pokitDok = new PokitDokAPIClient('clientID', 'clientSecret');
+        Test.setMock(HttpCalloutMock.class, 
+                     new PokitDokMockResponseGenerator(false, true, false));        
+        PokitDokAPIClient pokitDok = new PokitDokAPIClient(TEST_CLIENT_ID, TEST_CLIENT_SECRET, 
+	                                                       false);
 
         // Create an empty test JSON request
         Map<String,Object> eligibilityRequest = new Map<String,Object>();
@@ -129,35 +194,47 @@ public class PokitDokAPIClientTest {
             }
         }
     }
-    
+
     /**
-     * The testCalloutException method tests a borked HTTP connection.  The client 
-     * will return a manufactured JSON message will include a JSON field called 
-     * "error".
+     * The testSessionExpired method tests an HTTP response with a status code of 401.
+     * The client will try to replay the request after reauthenticating.  
+     * This is almost a complete.  Warm the cache with a fake session token to clear
+     * first call to authenticate().  It will come back with a token from the cache.
+     * When the actual request is made a 401 is returned, and the cache will be flushed
+     * and the authenticate() will be called again.  In the real world, this will
+     * succeed, but in this test, the second authenticate API call will also return
+     * a 401 response as well, so technically the second transaction is not replayed.
      */
     @isTest 
-    static void testCalloutException() {
+    static void testSessionExpired() {
+        // Warm the cache with a fake expired session token
+        PokitDokSessionCacheManager sessionManager = new PokitDokSessionCacheManager(TEST_CLIENT_ID);
+        sessionManager.putToken('EXPIRED_TOKEN');
+
         // Set mock callout class 
-        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator(true, false));        
-        PokitDokAPIClient pokitDok = new PokitDokAPIClient('clientID', 'clientSecret');
+        Test.setMock(HttpCalloutMock.class, 
+                     new PokitDokMockResponseGenerator(false, false, true));
+        PokitDokAPIClient pokitDok = new PokitDokAPIClient(TEST_CLIENT_ID, TEST_CLIENT_SECRET, 
+                                                           true);        
 
         // Create an empty test JSON request
         Map<String,Object> eligibilityRequest = new Map<String,Object>();
         String eligibilityResponse = pokitDok.eligibility(JSON.serialize(eligibilityRequest));
-        
+                
         // Verify there is an error message in the JSON response
         System.assert(eligibilityResponse != null);
-        String expectedCalloutExceptionMessage = '';
+        String expectedUnsuccessfulMessage = '';
         
         JSONParser parser = JSON.createParser(eligibilityResponse);
         while (parser.nextToken() != null) {
             if ((parser.getCurrentToken() == JSONToken.FIELD_NAME) && 
-                (parser.getText() == 'error')) {
+                (parser.getText() == 'errors')) {
                 parser.nextToken();
-                expectedCalloutExceptionMessage = parser.getText();
-                System.assertEquals(expectedCalloutExceptionMessage, 
-                                    PokitDokAPIClient.CALLOUT_EXCEPTION_MESSAGE);
+                expectedUnsuccessfulMessage = parser.getText();
+                System.assertEquals(expectedUnsuccessfulMessage, 
+                                    PokitDokMockResponseGenerator.SESSION_EXPIRED_MESSAGE);
             }
         }
-    }    
+    } 
 }
+

--- a/test/PokitDokAPIClientTest.apxc
+++ b/test/PokitDokAPIClientTest.apxc
@@ -46,8 +46,8 @@ public class PokitDokAPIClientTest {
     @isTest 
     static void testAuthentication() {
         // Set mock callout class 
-        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator(false, false, 
-                                                                              false));
+        Test.setMock(HttpCalloutMock.class, 
+	             new PokitDokMockResponseGenerator(false, false, false));
         PokitDokAPIClient pokitDok = new PokitDokAPIClient(TEST_CLIENT_ID, TEST_CLIENT_SECRET, 
                                                            true);
         String session_token = pokitDok.authenticate();

--- a/test/PokitDokAPIClientTest.apxc
+++ b/test/PokitDokAPIClientTest.apxc
@@ -51,7 +51,6 @@ public class PokitDokAPIClientTest {
         PokitDokAPIClient pokitDok = new PokitDokAPIClient(TEST_CLIENT_ID, TEST_CLIENT_SECRET, 
                                                            true);
         String session_token = pokitDok.authenticate();
-        session_token = pokitDok.authenticate();
         
         // Verify the session access token has been set
         System.assertEquals(session_token, PokitDokMockResponseGenerator.ACCESS_TOKEN);

--- a/test/PokitDokMockResponseGenerator.apxc
+++ b/test/PokitDokMockResponseGenerator.apxc
@@ -18,19 +18,23 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
     public final static String ACTIVITY_ID = '11111111';
     public final static String CORRELATION_ID = '99999999';
     public final static String UNSUCCESSFUL_MESSAGE = 'Unprocessable Entity';
+    public final static String SESSION_EXPIRED_MESSAGE = 'Unauthorized';
     
     // Configures whether or not to handle error conditions
-    public boolean isExceptionThrown = false;
-    public boolean isResponseUnsuccessful = false;
+    public Boolean isExceptionThrown = false;
+    public Boolean isResponseUnsuccessful = false;
+    public Boolean hasSessionExpired = false;
     
     /**
      * The constructor allows the calling test code to configure the mock response
      * generator to handle error conditions.
      */
-    public PokitDokMockResponseGenerator(boolean isExceptionThrown, 
-                                         boolean isResponseUnsuccessful) {
-        isExceptionThrown = isExceptionThrown;
-		isResponseUnsuccessful = isResponseUnsuccessful;
+    public PokitDokMockResponseGenerator(Boolean isExceptionThrown, 
+                                         Boolean isResponseUnsuccessful,
+                                         Boolean hasSessionExpired) {
+        this.isExceptionThrown = isExceptionThrown;
+        this.isResponseUnsuccessful = isResponseUnsuccessful;
+        this.hasSessionExpired = hasSessionExpired;
     }
     
     /**
@@ -47,7 +51,7 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
         if (isExceptionThrown) {
             CalloutException e = (CalloutException)CalloutException.class.newInstance();
             e.setMessage('Mock CalloutException thrown.');
-            throw e;   
+            throw e;
         }
 
         // Create a mocked response for testing an unsuccessful response
@@ -55,6 +59,11 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
             return createUnsuccessfulResponse();   
         }
 
+        // Create a mocked response for testing a session expiring
+        if (hasSessionExpired) {
+            return createSessionExpiredResponse();   
+        }
+        
         // Create a mocked response for testing authentication
         HttpResponse response = new HttpResponse();
         if (request.getEndpoint() == PokitDokAPIClient.POKITDOK_BASE_URL + 
@@ -67,6 +76,7 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
                                      PokitDokAPIClient.ELIGIBILITY_ENDPOINT) {			
             response = createEligibilityResponse();            
         }
+
         return response;
     }
     
@@ -80,7 +90,7 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
     private HTTPResponse createAuthenticationResponse() {
         // Create a fake authentication response
         HttpResponse response = new HttpResponse();
-		response.setStatusCode(200);
+        response.setStatusCode(200);
         response.setHeader('Content-Type', 'application/json');
 
         Map<String,Object> authenticationResponse = new Map<String,Object>();
@@ -101,7 +111,7 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
     private HTTPResponse createEligibilityResponse() {
         // Create a fake eligibility response
         HttpResponse response = new HttpResponse();
-		response.setStatusCode(200);
+        response.setStatusCode(200);
         response.setHeader('Content-Type', 'application/json');        
         
         Map<String,Object> eligibilityResponse = new Map<String,Object>();
@@ -128,7 +138,7 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
     private HTTPResponse createUnsuccessfulResponse() {
         // Create a fake unsuccessful authentication response
         HttpResponse response = new HttpResponse();
-		response.setStatusCode(422);
+        response.setStatusCode(422);
         response.setHeader('Content-Type', 'application/json');
 
         Map<String,Object> authenticationResponse = new Map<String,Object>();
@@ -137,4 +147,25 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
         
         return response;
     }
+    
+    /**
+     * The createSessionExpiredResponse method creates a mocked HTTPResponse to an 
+     * API endpoint.  It returns a status code of 401, however, that lets the calling
+     * code know that the session has expired and the token needs to be renewed.
+     * 
+     * @return the HTTPResponse with a 401 status code
+     */
+    private HTTPResponse createSessionExpiredResponse() {
+        // Create a fake unsuccessful authentication response
+        HttpResponse response = new HttpResponse();
+        response.setStatusCode(401);
+        response.setHeader('Content-Type', 'application/json');
+
+        Map<String,Object> apiResponse = new Map<String,Object>();
+        apiResponse.put('errors', SESSION_EXPIRED_MESSAGE);       
+        response.setBody(JSON.serialize(apiResponse));
+        
+        return response;
+    }    
 }
+

--- a/test/PokitDokSessionCacheManagerTest.apxc
+++ b/test/PokitDokSessionCacheManagerTest.apxc
@@ -1,0 +1,83 @@
+/**
+ * The PokitDokSessionCacheManagerTest class tests out the functionality of managing
+ * the OAuth access token for session management with the PokitDok Platform.
+ * 
+ * Copyright (C) 2016, All Rights Reserved, PokitDok, Inc.
+ * https://platform.pokitdok.com
+ *
+ * Please see the License.txt file for more information.
+ * All other rights reserved.
+ */
+@isTest
+public class PokitDokSessionCacheManagerTest {
+    
+    public final static String TEST_TOKEN = 'TEST_TOKEN';
+    public final static String TEST_CLIENT_ID = 'ClientID';
+    
+    /**
+     * The testCacheEnabled method tests that the organization cache is available for 
+     * usage.
+     */
+    @isTest 
+    static void testCacheAvailable() {
+        // Verify the cache partition is available
+        PokitDokSessionCacheManager sessionManager = new PokitDokSessionCacheManager(TEST_CLIENT_ID);
+        System.assert(sessionManager.cacheEnabled);
+
+        Map<String, Object> cacheStatistics = sessionManager.getCacheStatistics();        
+        String default_partition = (String) cacheStatistics.get('default_partition');        
+        System.assertNotEquals('', default_partition);
+    }
+
+    /**
+     * The testStorage method tests that the storage, retrieval and removal of session
+     * access tokens work.
+     */
+    @isTest 
+    static void testProperStorage() {
+        // Put, get, remove, rinse, repeat
+        PokitDokSessionCacheManager sessionManager = new PokitDokSessionCacheManager(TEST_CLIENT_ID);
+        sessionManager.putToken(TEST_TOKEN);
+		
+        String retrievedToken = sessionManager.getToken();
+        System.assertEquals(TEST_TOKEN, retrievedToken);
+       
+        Boolean removedToken = sessionManager.removeToken();
+        System.assertEquals(true, removedToken);
+    }
+    
+    /**
+     * The testCacheMiss method tests that retrieval fails when trying to access a token for
+     * a completely different client app.
+     */
+    @isTest 
+    static void testCacheMiss() {
+        // Register the cache manager with the normal Client ID and add the token to it
+        PokitDokSessionCacheManager sessionManager = new PokitDokSessionCacheManager(TEST_CLIENT_ID);
+        sessionManager.putToken(TEST_TOKEN);
+        
+        // Try to retrieve it from a cache manager registered with a different Client ID
+        sessionManager = new PokitDokSessionCacheManager(TEST_CLIENT_ID + 'xxx');
+        String retrievedToken = sessionManager.getToken();
+        System.assertEquals(null, retrievedToken);
+    }
+    
+    /**
+    * The testCacheDisabled method tests that the organization cache is not available, the 
+    * cache storage methods aren't available.
+    */
+    @isTest 
+    static void testCacheUnavailable() {
+        // Fake unavailability by manually turning off the cacheEnabled flag
+        PokitDokSessionCacheManager sessionManager = new PokitDokSessionCacheManager(TEST_CLIENT_ID);
+        sessionManager.cacheEnabled = false;
+        sessionManager.putToken(TEST_TOKEN);
+		
+        String retrievedToken = sessionManager.getToken();
+        System.assertEquals(null, retrievedToken);
+
+        Boolean removedToken = sessionManager.removeToken();
+        System.assertEquals(false, removedToken);
+    }
+}
+


### PR DESCRIPTION
Implemented caching of the session access token.  

This works by utilizing the Salesforce Platform Cache.  There are two types of caches: Session and Org.  I employ the Org cache so that different folks with different sessions can all use the same access token (since it is based on a singular Client ID.)  If a particular has different PokitDok Platform Apps, each with their own Client ID, the tokens will be stored separately.

This provides a detailed look at how Salesforce Platform Cache works and how it is configured.

The API Client follows the standard pattern of authentication.  It first looks in the cache for a token and uses it if it is available.  If the request returns a 401, the cache is flushed, the App is reauthenticated with the new token cached and the original API request is replayed.

To facilitate token cache management a new PokitDokSessionCacheManager was created.  This has high level functions to get/put/remove tokens and also abstracts the verification that the Salesforce Platform Cache is set up and there is a default Cache Partition.

The tests have all been updated to test out the new functionality.  The documentation and reference implementation has also been updated as well.