### PR TITLE
Updates to the reference implementation and implemented access token caching

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,10 @@
 PokitDok Platform API Client for Salesforce APEX 
-=======================================
+================================================
 
 Resources
 ---------
 
-Please see the documentation_ for detailed information on all of the PokitDok Platform APIs.
-The documentation includes Python client examples for each API.
+Please see the documentation_ for detailed information on all of the PokitDok Platform APIs.  The documentation includes APEX client examples for each of the implemented APIs.
 
 Report API client issues_ on GitHub
 
@@ -13,153 +12,55 @@ Report API client issues_ on GitHub
 Quick start
 -----------
 
-.. code-block:: python
+.. code-block:: java
 
-    import pokitdok
+    // Instantiate a PokitDokAPIClient with your credentials
+    PokitDokAPIClient pokitdok = new PokitDokAPIClient('<CLIENT_ID>', '<CLIENT_SECRET>');
 
-    pd = pokitdok.api.connect('<your client id>', '<your client secret>')
+    // Create an eligibility request payload
+    Map<String,String> member = new Map<String,String>();
+    member.put('birth_date', '1970-01-01');
+    member.put('first_name', 'John');
+    member.put('last_name', 'Smith');
+    member.put('id', '3141592653');
+    eligibilityRequest.put('member',member);
 
-    #submit an eligibility request
-    pd.eligibility({
-        "member": {
-            "birth_date": "1970-01-01",
-            "first_name": "Jane",
-            "last_name": "Doe",
-            "id": "W000000000"
-        },
-        "trading_partner_id": "MOCKPAYER"
-    })
+    Map<String,String> provider = new Map<String,String>();
+    provider.put('first_name', 'Jane');
+    provider.put('last_name', 'Doe');
+    provider.put('npi', '1467560003');
+    eligibilityRequest.put('provider',provider);
 
-Making Requests
----------------
-
-The client offers a few options for making API requests.
-High level functions are available for each of the APIs for convenience.
-If your application would prefer to interact with the APIs at a lower level,
-you may elect to use the general purpose request method or one of the http method aliases built around it.
-
-.. code-block:: python
-
-    # a low level "request" method is available that allows you to have more control over the construction of the API request
-    pd.request('/activities', method='get')
-
-    pd.request('/eligibility/', method='post', data={
-        "member": {
-            "birth_date": "1970-01-01",
-            "first_name": "Jane",
-            "last_name": "Doe",
-            "id": "W000000000"
-        },
-        "trading_partner_id": "MOCKPAYER"
-    })
-
-    # Convenience methods are available for the commonly used http methods built around the request method
-    pd.get('/activities')
-
-    pd.post('/eligibility/', data={
-        "member": {
-            "birth_date": "1970-01-01",
-            "first_name": "Jane",
-            "last_name": "Doe",
-            "id": "W000000000"
-        },
-        "trading_partner_id": "MOCKPAYER"
-    })
-
-    # higher level functions are also available to access the APIs
-    pd.activities()
-
-    pd.eligibility({
-        "member": {
-            "birth_date": "1970-01-01",
-            "first_name": "Jane",
-            "last_name": "Doe",
-            "id": "W000000000"
-        },
-        "trading_partner_id": "MOCKPAYER"
-    })
+    eligibilityRequest.put('trading_partner_id','MOCKPAYER');
+        
+    // Make the call to the eligibility API.  The response is serialized JSON.
+    String eligibilityResponse = pokitdok.eligibility(JSON.serialize(eligibilityRequest));
 
 
-Authentication and Authorization
---------------------------------
+Installation
+------------
 
-Access to PokitDok APIs is controlled via OAuth2.  Most APIs are accessible with an
-access token acquired via a client credentials grant type since scope and account context
-are not required for their use.  If you're just interested in using APIs that don't
-require a specific scope and account context, you simply supply your app credentials
-and you're ready to go:
+There is not presently an artifact for this codebase that can be installed either at the command line or from within the Salesforce AppExchange Marketplace.  The code in this repository should copied, class by class, into a Salesforce Sandbox environment and tested there, before deploying to a Production environment.
 
 
-.. code-block:: python
+Configuration
+-------------
 
-    import pokitdok
+In addition to bringing the source code into the Sandbox environment, the system need to be configured appropriately to allow the HTTP calls to go through.  Create a ``Remote Site`` by traversing ``Security Controls`` > ``Remote Site Settings`` and use these values:
 
-    pd = pokitdok.api.connect('<your client id>', '<your client secret>')
+  :Remote Site Name: PokitDok_Platform
+  :Remote Site URL: https://platform.pokitdok.com
+  
 
+Testing
+-------
 
+There is unit test coverage for the core API Client code. The tests exercise authentication and each of the implemented API endpoints.  Because tests are not allowed to go across the wire, a Mock Response Generator is supplied that will return mocked responses for the endpoints for which they have registered.
 
-if you'd like your access token to automatically refresh when using the authorization flow, you can connect like this:
+The tests has been verified to run successfully on Salesforce on Winter '17.
 
-.. code-block:: python
+The repository also contains an example reference implementation that will use the API Client to make actual calls against the PokitDok Platform APIs.  You will need to sign up for free at http://platform.pokitdok.com for your own App credentials.  See the example_ page for more information on the configuration necessary to fully test out the actual API calls.
 
-    pd = pokitdok.api.connect('<your client id>', '<your client secret>', auto_refresh=True)
-
-
-That instructs the Python client to use your refresh token to request a new access token
-when the access token expires after 1 hour.
-
-For APIs that require a specific scope/account context in order to execute,  you'll need to request
-authorization from a user prior to requesting an access token.
-
-.. code-block:: python
-
-    def new_token_handler(token):
-        print('new token received: {0}'.format(token))
-        # persist token information for later use
-
-    pd = pokitdok.api.connect('<your client id>', '<your client secret>', redirect_uri='https://yourapplication.com/redirect_uri', scope=['user_schedule'], auto_refresh=True, token_refresh_callback=new_token_handler)
-
-    authorization_url, state = pd.authorization_url()
-    #redirect the user to authorization_url
-
-
-You may set your application's redirect uri value via the PokitDok Platform Dashboard (https://platform.pokitdok.com)
-The redirect uri specified for authorization must match your registered redirect uri exactly.
-
-After a user has authorized the requested scope, the PokitDok Platform will redirect back to your application's
-Redirect URI along with a code and the state value that was included in the authorization url.
-If the state matches the original value, you may use the code to fetch an access token:
-
-.. code-block:: python
-
-    pd.fetch_access_token(code='<code value received via redirect>')
-
-
-Your application may now access scope protected APIs on behalf of the user that authorized the request.
-Be sure to retain the token information to ensure you can easily request an access token when you need it
-without going back through the authorization code grant redirect flow.   If you don't retain the token
-information or the user revokes your authorization, you'll need to go back through the authorization process
-to get a new access token for scope protected APIs.
-
-Check SSL protocol and cipher
------------------------------
-
-.. code-block:: python
-
-    pd.request('/ssl/', method='get')
-
-Supported Python Versions
--------------------------
-
-This library aims to support and is tested against these Python versions:
-
-* 2.6.9
-* 2.7.6
-* 3.4.0
-* 3.5.0
-* PyPy
-
-You may have luck with other interpreters - let us know how it goes.
 
 License
 -------
@@ -168,5 +69,6 @@ Copyright (c) 2016 PokitDok, Inc.  See LICENSE_ for details.
 
 .. _documentation: https://platform.pokitdok.com/documentation/v4/?apex#
 .. _issues: https://github.com/pokitdok/pokitdok-apex/issues
+.. _example: https://github.com/pokitdok/pokitdok-apex/tree/dev/example
 .. _LICENSE: LICENSE.txt
 

--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,34 @@ Create a new ``Remote Site`` with these values:
 Reference the APEX Developer's Guide for additional information about adding a `Remote Site <https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_callouts_remote_site_settings.htm>`_.
 
 
+Platform Cache
+--------------
+
+OAuth session access tokens can be persisted and used across the organization to eliminate the need to authenticate with the PokitDok Platform servers with each API request.  This is accomplished by utilizing the Salesforce Platform Cache.
+
+The Salesforce Platform Cache lets you store and retrieve data that is shared across your organization. Put, retrieve, or remove cache values by using the Cache.Org and Org.Partition classes in the Cache namespace. Use the Platform Cache Partition tool to create or remove org partitions and allocate their cache capacities to balance performance across apps.
+
+Unlike session cache, org cache is accessible across sessions, requests, and org users and profiles. Org cache expires when its specified time-to-live is reached, in this case, 60 minutes.
+
+If your organization has not set up a default cache partition by following these steps.
+
+Navigate: ``Setup`` > ``Platform Cache`` > ``New Platform Cache Partition``
+
+Create a default cache with these or similar configuration parameters.
+
+*Details*
+
+:Label: BaseOrgCachePartition
+:Name: BaseOrgCachePartition
+:Default Partition: X
+:Description: Default Org level cache partition
+
+*Org Cache Allocation*
+
+:Organization: 5
+
+Reference the APEX Developer's Guide for additional information about configuring `Platform Cache <https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_cache_namespace_overview.htm>`_.
+
 Testing
 -------
 
@@ -79,4 +107,3 @@ Copyright (c) 2016 PokitDok, Inc.  See LICENSE_ for details.
 .. _issues: https://github.com/pokitdok/pokitdok-apex/issues
 .. _example: https://github.com/pokitdok/pokitdok-apex/tree/dev/example
 .. _LICENSE: LICENSE.txt
-

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ Testing
 
 There is unit test coverage for the core API Client code. The tests exercise authentication and each of the implemented API endpoints.  Because tests are not allowed to go across the wire, a Mock Response Generator is supplied that will return mocked responses for the endpoints for which they have registered.
 
-The tests has been verified to run successfully on Salesforce on Winter '17.
+The tests has been verified to run successfully on Salesforce on Winter '17 and code coverage is over 93%.
 
 The repository also contains an example reference implementation that will use the API Client to make actual calls against the PokitDok Platform APIs.  You will need to sign up for free at http://platform.pokitdok.com for your own App credentials.  See the example_ page for more information on the configuration necessary to fully test out the actual API calls.
 

--- a/README.rst
+++ b/README.rst
@@ -46,11 +46,17 @@ There is not presently an artifact for this codebase that can be installed eithe
 Configuration
 -------------
 
-In addition to bringing the source code into the Sandbox environment, the system need to be configured appropriately to allow the HTTP calls to go through.  Create a ``Remote Site`` by traversing ``Security Controls`` > ``Remote Site Settings`` and use these values:
+In addition to bringing the source code into the Sandbox environment, the system needs to be configured appropriately to allow the HTTP calls to go through.
+
+Navigate: ``Security Controls`` > ``Remote Site Settings`` > ``New``
+
+Create a new ``Remote Site`` with these values:
 
 :Remote Site Name: PokitDok_Platform
 :Remote Site URL: https://platform.pokitdok.com
   
+Reference the APEX Developer's Guide for additional information about adding a `Remote Site <https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_callouts_remote_site_settings.htm>`_.
+
 
 Testing
 -------

--- a/README.rst
+++ b/README.rst
@@ -48,8 +48,8 @@ Configuration
 
 In addition to bringing the source code into the Sandbox environment, the system need to be configured appropriately to allow the HTTP calls to go through.  Create a ``Remote Site`` by traversing ``Security Controls`` > ``Remote Site Settings`` and use these values:
 
-  :Remote Site Name: PokitDok_Platform
-  :Remote Site URL: https://platform.pokitdok.com
+:Remote Site Name: PokitDok_Platform
+:Remote Site URL: https://platform.pokitdok.com
   
 
 Testing

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,172 @@
+PokitDok Platform API Client for Salesforce APEX 
+=======================================
+
+Resources
+---------
+
+Please see the documentation_ for detailed information on all of the PokitDok Platform APIs.
+The documentation includes Python client examples for each API.
+
+Report API client issues_ on GitHub
+
+
+Quick start
+-----------
+
+.. code-block:: python
+
+    import pokitdok
+
+    pd = pokitdok.api.connect('<your client id>', '<your client secret>')
+
+    #submit an eligibility request
+    pd.eligibility({
+        "member": {
+            "birth_date": "1970-01-01",
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "id": "W000000000"
+        },
+        "trading_partner_id": "MOCKPAYER"
+    })
+
+Making Requests
+---------------
+
+The client offers a few options for making API requests.
+High level functions are available for each of the APIs for convenience.
+If your application would prefer to interact with the APIs at a lower level,
+you may elect to use the general purpose request method or one of the http method aliases built around it.
+
+.. code-block:: python
+
+    # a low level "request" method is available that allows you to have more control over the construction of the API request
+    pd.request('/activities', method='get')
+
+    pd.request('/eligibility/', method='post', data={
+        "member": {
+            "birth_date": "1970-01-01",
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "id": "W000000000"
+        },
+        "trading_partner_id": "MOCKPAYER"
+    })
+
+    # Convenience methods are available for the commonly used http methods built around the request method
+    pd.get('/activities')
+
+    pd.post('/eligibility/', data={
+        "member": {
+            "birth_date": "1970-01-01",
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "id": "W000000000"
+        },
+        "trading_partner_id": "MOCKPAYER"
+    })
+
+    # higher level functions are also available to access the APIs
+    pd.activities()
+
+    pd.eligibility({
+        "member": {
+            "birth_date": "1970-01-01",
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "id": "W000000000"
+        },
+        "trading_partner_id": "MOCKPAYER"
+    })
+
+
+Authentication and Authorization
+--------------------------------
+
+Access to PokitDok APIs is controlled via OAuth2.  Most APIs are accessible with an
+access token acquired via a client credentials grant type since scope and account context
+are not required for their use.  If you're just interested in using APIs that don't
+require a specific scope and account context, you simply supply your app credentials
+and you're ready to go:
+
+
+.. code-block:: python
+
+    import pokitdok
+
+    pd = pokitdok.api.connect('<your client id>', '<your client secret>')
+
+
+
+if you'd like your access token to automatically refresh when using the authorization flow, you can connect like this:
+
+.. code-block:: python
+
+    pd = pokitdok.api.connect('<your client id>', '<your client secret>', auto_refresh=True)
+
+
+That instructs the Python client to use your refresh token to request a new access token
+when the access token expires after 1 hour.
+
+For APIs that require a specific scope/account context in order to execute,  you'll need to request
+authorization from a user prior to requesting an access token.
+
+.. code-block:: python
+
+    def new_token_handler(token):
+        print('new token received: {0}'.format(token))
+        # persist token information for later use
+
+    pd = pokitdok.api.connect('<your client id>', '<your client secret>', redirect_uri='https://yourapplication.com/redirect_uri', scope=['user_schedule'], auto_refresh=True, token_refresh_callback=new_token_handler)
+
+    authorization_url, state = pd.authorization_url()
+    #redirect the user to authorization_url
+
+
+You may set your application's redirect uri value via the PokitDok Platform Dashboard (https://platform.pokitdok.com)
+The redirect uri specified for authorization must match your registered redirect uri exactly.
+
+After a user has authorized the requested scope, the PokitDok Platform will redirect back to your application's
+Redirect URI along with a code and the state value that was included in the authorization url.
+If the state matches the original value, you may use the code to fetch an access token:
+
+.. code-block:: python
+
+    pd.fetch_access_token(code='<code value received via redirect>')
+
+
+Your application may now access scope protected APIs on behalf of the user that authorized the request.
+Be sure to retain the token information to ensure you can easily request an access token when you need it
+without going back through the authorization code grant redirect flow.   If you don't retain the token
+information or the user revokes your authorization, you'll need to go back through the authorization process
+to get a new access token for scope protected APIs.
+
+Check SSL protocol and cipher
+-----------------------------
+
+.. code-block:: python
+
+    pd.request('/ssl/', method='get')
+
+Supported Python Versions
+-------------------------
+
+This library aims to support and is tested against these Python versions:
+
+* 2.6.9
+* 2.7.6
+* 3.4.0
+* 3.5.0
+* PyPy
+
+You may have luck with other interpreters - let us know how it goes.
+
+License
+-------
+
+Copyright (c) 2016 PokitDok, Inc.  See LICENSE_ for details.
+
+.. _documentation: https://platform.pokitdok.com/documentation/v4/?apex#
+.. _issues: https://github.com/pokitdok/pokitdok-apex/issues
+.. _LICENSE: LICENSE.txt
+

--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,10 @@
-PokitDok Platform API Client for Salesforce APEX 
+PokitDok Platform API Client for Salesforce Apex
 ================================================
 
 Resources
 ---------
 
-Please see the documentation_ for detailed information on all of the PokitDok Platform APIs.  The documentation includes APEX client examples for each of the implemented APIs.
+Please see the documentation_ for detailed information on all of the PokitDok Platform APIs.  The documentation includes Apex client examples for each of the implemented APIs.
 
 Report API client issues_ on GitHub
 

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,8 @@ Quick start
     PokitDokAPIClient pokitdok = new PokitDokAPIClient('<CLIENT_ID>', '<CLIENT_SECRET>');
 
     // Create an eligibility request payload
+    Map<String,Object> eligibilityRequest = new Map<String,Object>();
+    
     Map<String,String> member = new Map<String,String>();
     member.put('birth_date', '1970-01-01');
     member.put('first_name', 'John');

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ The Salesforce Platform Cache lets you store and retrieve data that is shared ac
 
 Unlike session cache, org cache is accessible across sessions, requests, and org users and profiles. Org cache expires when its specified time-to-live is reached, in this case, 60 minutes.
 
-If your organization has not set up a default cache partition by following these steps.
+If your organization has not set up a default cache partition, you may do so by following these steps.
 
 Navigate: ``Setup`` > ``Platform Cache`` > ``New Platform Cache Partition``
 

--- a/example/Eligibility.apxc
+++ b/example/Eligibility.apxc
@@ -6,7 +6,8 @@
  * 
  * {!REQUIRESCRIPT("/soap/ajax/25.0/connection.js")}
  * {!REQUIRESCRIPT("/soap/ajax/25.0/apex.js")}
- * var result = sforce.apex.execute("Eligibility","runEligibilityCheck",{});
+ * var patientId='{!Patient__c.Name}';
+ * var result = sforce.apex.execute("Eligibility","runEligibilityCheck",{patientID: patientId});
  * alert(result);
  * window.location.reload();
  * sforce.debug.trace=true;
@@ -31,10 +32,11 @@ global with sharing class Eligibility {
      * payload with the patient's PHI, executes the eligibility method and does something 
      * meaningful with the JSON response.
      */
-    webservice static String runEligibilityCheck() {
+    webservice static String runEligibilityCheck(String patientID) {
+        
         // Use the PokitDok API Client to make an eligibility request
         PokitDokAPIClient pokitdok = new PokitDokAPIClient(CLIENT_ID, CLIENT_SECRET);
-        String eligibilityRequest = buildEligibilityRequest();
+        String eligibilityRequest = buildEligibilityRequest(patientID);
         String eligibilityResponse = pokitdok.eligibility(eligibilityRequest);
         
         // Check for errors
@@ -45,11 +47,11 @@ global with sharing class Eligibility {
                 (parser.getText() == 'error') || (parser.getText() == 'errors')) {
                     return 'Unable to process your eligibility request at this time.  The ' +
                         'original request has been logged.';
-                }
+            }
         }
         
         // Otherwise, do something meaningful with the response
-        return parseEligibilityResponse(eligibilityResponse);
+        return parseEligibilityResponse(eligibilityResponse, patientID);
     }
     
     /**
@@ -75,15 +77,32 @@ global with sharing class Eligibility {
      * 
      * @return the serialized JSON to send to the eligibility endpoint
      */
-    private static String buildEligibilityRequest() {        
+    private static String buildEligibilityRequest(String patientID) {
+        
+        Patient__c patient = [select Id, Name, Birth_Date__c, First_Name__c, Last_Name__c,
+                              Member_ID__c, Payer__c 
+                              from Patient__c 
+                              where Name = :patientID];
+        
+        String birthYear = String.valueof(patient.Birth_Date__c.year());
+        String birthMonth = String.valueof(patient.Birth_Date__c.month());
+        String birthDay = String.valueof(patient.Birth_Date__c.day());
+        if(birthMonth.length() == 1) {
+          birthMonth = '0' + birthMonth;
+        }
+        if(birthDay.length() ==1 ) {
+          birthDay = '0' + birthDay;
+        }
+        String birthDate = birthYear + '-' + birthMonth +  + '-' + birthDay;
+        
         // Create the object map
         Map<String,Object> eligibilityRequest = new Map<String,Object>();
         
-        Map<String,String> member = new Map<String,String>();
-        member.put('birth_date', '1970-01-01');
-        member.put('first_name', 'John');
-        member.put('last_name', 'Smith');
-        member.put('id', '3141592653');
+        Map<String,String> member = new Map<String,String>();        
+        member.put('birth_date', birthDate);
+        member.put('first_name', patient.First_Name__c);
+        member.put('last_name', patient.Last_Name__c);
+        member.put('id', patient.Member_ID__c);
         eligibilityRequest.put('member',member);
         
         Map<String,String> provider = new Map<String,String>();
@@ -92,7 +111,7 @@ global with sharing class Eligibility {
         provider.put('npi', '1467560003');
         eligibilityRequest.put('provider',provider);
         
-        eligibilityRequest.put('trading_partner_id','MOCKPAYER');        
+        eligibilityRequest.put('trading_partner_id', patient.Payer__c);        
         
         // Serialize to JSON
         return JSON.serialize(eligibilityRequest);
@@ -108,7 +127,13 @@ global with sharing class Eligibility {
      * @param response is the JOSN response from the eligibilty request
      * @return some meaningful text to send back to the end user
      */
-    private static String parseEligibilityResponse(String response) {
+    private static String parseEligibilityResponse(String response, String patientID) {
+        
+        Patient__c patient = [select Id, Name, Birth_Date__c, First_Name__c, Last_Name__c,
+                              Member_ID__c, Payer__c 
+                              from Patient__c 
+                              where Name = :patientID];
+        
         String meaningfulResponse = '';
         boolean isActive = false;
         Date planBeginDate = null;
@@ -121,13 +146,17 @@ global with sharing class Eligibility {
                 (parser.getText() == 'active')) {
                     parser.nextToken();
                     isActive = parser.getBooleanValue();
-                }
+                    patient.Active_Coverage__c = isActive;
+            }
             if ((parser.getCurrentToken() == JSONToken.FIELD_NAME) && 
                 (parser.getText() == 'plan_begin_date')) {
                     parser.nextToken();
                     planBeginDate = parser.getDateValue();
-                }
+                    patient.Plan_Begin_Date__c = planBeginDate;
+            }
         }
+        
+        update patient;
         
         // Asssemble the message
         if (isActive) {
@@ -139,5 +168,5 @@ global with sharing class Eligibility {
         }
         
         return meaningfulResponse;
-    }    
+    }  
 }

--- a/example/Eligibility.apxc
+++ b/example/Eligibility.apxc
@@ -1,0 +1,135 @@
+/**
+ * The Eligibility class is a example driver of how to use the PokitDok API Client to run
+ * an eligibility check on a patient.  It accomplishes this within its runEligibilityCheck()
+ * method.   This example code can be executed in a Salesforce instance with a custom OnClick
+ * JavaScript button on an object detail page configured like this:
+ * 
+ * {!REQUIRESCRIPT("/soap/ajax/25.0/connection.js")}
+ * {!REQUIRESCRIPT("/soap/ajax/25.0/apex.js")}
+ * var result = sforce.apex.execute("Eligibility","runEligibilityCheck",{});
+ * alert(result);
+ * window.location.reload();
+ * sforce.debug.trace=true;
+ * 
+ * The Client ID and Client Secret credentials passed into the API Client constructor are
+ * obtained by signing up for free at https://platform.pokitdok.com.
+ */
+global with sharing class Eligibility {    
+    static final String CLIENT_ID = '<YOUR_CLIENT_ID>';
+    static final String CLIENT_SECRET = '<YOUR_CLIENT_SECRET>';
+    
+    /**
+     * The runEligibilityCheck() method instantiates the API Client, manufactures a JSON
+     * payload with the patient's PHI, executes the eligibility method and does something 
+     * meaningful with the JSON response.
+     */
+    webservice static String runEligibilityCheck() {
+        // Use the PokitDok API Client to make an eligibility request
+        PokitDokAPIClient pokitdok = new PokitDokAPIClient(CLIENT_ID, CLIENT_SECRET);
+        String eligibilityRequest = buildEligibilityRequest();
+        String eligibilityResponse = pokitdok.eligibility(eligibilityRequest);
+        
+        // Check for errors
+        String errorMessage = null;
+        JSONParser parser = JSON.createParser(eligibilityResponse);
+        while (parser.nextToken() != null) {
+            if ((parser.getCurrentToken() == JSONToken.FIELD_NAME) && 
+                (parser.getText() == 'error') || (parser.getText() == 'errors')) {
+                    return 'Unable to process your eligibility request at this time.  The ' +
+                        'original request has been logged.';
+                }
+        }
+        
+        // Otherwise, do something meaningful with the response
+        return parseEligibilityResponse(eligibilityResponse);
+    }
+    
+    /**
+     * The buildEligibilityRequest() method abstracts the extraction of the data necessary
+     * data to build the payload for the eligibility request.  The PHI may exist in one or
+     * many custom Salesforce objects.  For the purposes of this example, the data is simply
+     * hardcoded and produces a JSON payload that looks like this:
+     *
+     * {
+     *     "member": {
+     *         "birth_date": "1970-01-01",
+     *         "first_name": "John",
+     *         "last_name": "Smith",
+     *         "id": "3141592653"
+     *     },
+     *     "provider": {
+     *         "first_name": "Jane",
+     *         "last_name": "Doe",
+     *         "npi": "1467560003"
+     *     },
+     *     "trading_partner_id": "MOCKPAYER"
+     * }
+     * 
+     * @return the serialized JSON to send to the eligibility endpoint
+     */
+    private static String buildEligibilityRequest() {        
+        // Create the object map
+        Map<String,Object> eligibilityRequest = new Map<String,Object>();
+        
+        Map<String,String> member = new Map<String,String>();
+        member.put('birth_date', '1970-01-01');
+        member.put('first_name', 'John');
+        member.put('last_name', 'Smith');
+        member.put('id', '3141592653');
+        eligibilityRequest.put('member',member);
+        
+        Map<String,String> provider = new Map<String,String>();
+        provider.put('first_name', 'Jane');
+        provider.put('last_name', 'Doe');
+        provider.put('npi', '1467560003');
+        eligibilityRequest.put('provider',provider);
+        
+        eligibilityRequest.put('trading_partner_id','MOCKPAYER');        
+        
+        // Serialize to JSON
+        return JSON.serialize(eligibilityRequest);
+    }
+    
+    /**
+     * The parseEligibilityResponse parses the JSON response from the eligibility API
+     * call and produces a meaningful message for the user.  It demonstrates how to pull
+     * out a few fields in the JSON to construct a message.  In this case, the message
+     * conveys to the user that the patient's insurance coverage is currently active, as
+     * well as when coverage began under the plan.
+     * 
+     * @param response is the JOSN response from the eligibilty request
+     * @return some meaningful text to send back to the end user
+     */
+    private static String parseEligibilityResponse(String response) {
+        String meaningfulResponse = '';
+        boolean isActive = false;
+        Date planBeginDate = null;
+        
+        // Parse the response, extracting the active flag and the date that plan coverage
+        // began.
+        JSONParser parser = JSON.createParser(response);
+        while (parser.nextToken() != null) {
+            if ((parser.getCurrentToken() == JSONToken.FIELD_NAME) && 
+                (parser.getText() == 'active')) {
+                    parser.nextToken();
+                    isActive = parser.getBooleanValue();
+                }
+            if ((parser.getCurrentToken() == JSONToken.FIELD_NAME) && 
+                (parser.getText() == 'plan_begin_date')) {
+                    parser.nextToken();
+                    planBeginDate = parser.getDateValue();
+                }
+        }
+        
+        // Asssemble the message
+        if (isActive) {
+            meaningfulResponse = 'The patient\'s coverage is active and began on ' + 
+                planBeginDate.format();
+        }
+        else {
+            meaningfulResponse = 'The patient\'s coverage has lapsed and is not active';
+        }
+        
+        return meaningfulResponse;
+    }    
+}

--- a/example/Eligibility.apxc
+++ b/example/Eligibility.apxc
@@ -35,7 +35,7 @@ global with sharing class Eligibility {
     webservice static String runEligibilityCheck(String patientID) {
         
         // Use the PokitDok API Client to make an eligibility request
-        PokitDokAPIClient pokitdok = new PokitDokAPIClient(CLIENT_ID, CLIENT_SECRET);
+        PokitDokAPIClient pokitdok = new PokitDokAPIClient(CLIENT_ID, CLIENT_SECRET, true);
         String eligibilityRequest = buildEligibilityRequest(patientID);
         String eligibilityResponse = pokitdok.eligibility(eligibilityRequest);
         
@@ -135,7 +135,7 @@ global with sharing class Eligibility {
                               where Name = :patientID];
         
         String meaningfulResponse = '';
-        boolean isActive = false;
+        Boolean isActive = false;
         Date planBeginDate = null;
         
         // Parse the response, extracting the active flag and the date that plan coverage
@@ -170,3 +170,4 @@ global with sharing class Eligibility {
         return meaningfulResponse;
     }  
 }
+

--- a/example/Eligibility.apxc
+++ b/example/Eligibility.apxc
@@ -13,8 +13,16 @@
  * 
  * The Client ID and Client Secret credentials passed into the API Client constructor are
  * obtained by signing up for free at https://platform.pokitdok.com.
+ * 
+ * Copyright (C) 2016, All Rights Reserved, PokitDok, Inc.
+ * https://platform.pokitdok.com
+ *
+ * Please see the License.txt file for more information.
+ * All other rights reserved.
  */
 global with sharing class Eligibility {    
+ 
+    // These are your credentials
     static final String CLIENT_ID = '<YOUR_CLIENT_ID>';
     static final String CLIENT_SECRET = '<YOUR_CLIENT_SECRET>';
     

--- a/example/README.rst
+++ b/example/README.rst
@@ -1,41 +1,101 @@
-PokitDok Platform API Client for Salesforce APEX 
-=======================================
+APEX Reference Implementation
+=============================
 
-Resources
----------
+Scenario
+--------
 
-Please see the documentation_ for detailed information on all of the PokitDok Platform APIs.
-The documentation includes APEX client examples for each of the implemented APIs.
+Imagine there is a ``Patient`` custom object that stores basic PHI of individual patients at a medical facility.  In order to verify the patient has active insurance coverage, an eligibility request needs to be performed.  
 
-Report API client issues_ on GitHub
+The reference implementation assumes a small ``Patient`` custom object exists that has a custom Javascript button that will execute the code necessary to utilize the PokitDok Platform API Client to make the eligibility request.
+
+It is necessary to have many administrative privileges in order to set up the system to execute the reference implementation.
+
+It is also assumed that the source code has been installed in the sandbox environment.
 
 
-Quick start
------------
+Patient Object
+--------------
 
-.. code-block:: apex
+Navigate: ``Setup`` > ``Create`` > ``Objects`` > ``New``
 
-    // Instantiate a PokitDokAPIClient with your credentials
-    PokitDokAPIClient pokitdok = new PokitDokAPIClient('<CLIENT_ID>', '<CLIENT_SECRET>');
+Create a new custom object to capture patient data.  Configure the field-level security options for each field as appropriate, and add to the ``Patient Layout``.
 
-    // Create an eligibility request payload
-    Map<String,String> member = new Map<String,String>();
-    member.put('birth_date', '1970-01-01');
-    member.put('first_name', 'John');
-    member.put('last_name', 'Smith');
-    member.put('id', '3141592653');
-    eligibilityRequest.put('member',member);
++-----------------+--------------------+------------+
+| Field Label     | API Name           | Data Type  |
++=================+====================+============+
+| Patient ID      | Name               | Text(80)   |
++-----------------+--------------------+------------+ 
+| Active Coverage | Active_Coverage__c | Checkbox   |
++-----------------+--------------------+------------+ 
+| Birth Date      | Birth_Date__c      | Date       |
++-----------------+--------------------+------------+ 
+| First Name      | First_Name__c      | Text(32)   |
++-----------------+--------------------+------------+ 
+| Last Name       | Last_Name__c       | Text(32)   |
++-----------------+--------------------+------------+ 
+| Member ID       | Member_ID__c       | Text(32)   |
++-----------------+--------------------+------------+ 
+| Payer           | Payer__c           | Picklist   |
++-----------------+--------------------+------------+ 
+| Plan Begin Date | Plan_Begin_Date__c | Date       |
++-----------------+--------------------+------------+
 
-    Map<String,String> provider = new Map<String,String>();
-    provider.put('first_name', 'Jane');
-    provider.put('last_name', 'Doe');
-    provider.put('npi', '1467560003');
-    eligibilityRequest.put('provider',provider);
+For the ``Payer`` dropdown, add a single value of *MOCKPAYER*.
 
-    eligibilityRequest.put('trading_partner_id','MOCKPAYER');
-        
-    // Make the call to the eligibility API.  The response is serialized JSON.
-    String eligibilityResponse = pokitdok.eligibility(JSON.serialize(eligibilityRequest));
+
+Patients Tab
+------------
+
+Navigate: ``Setup`` > ``Create`` > ``Tabs`` > ``New``
+
+Create a new ``Patients`` Tab for the ``Patient`` object.  There was a **Caduceus** tab style that seemed appropriate.  You should now be allowed to traverse to the Patients views to create records.
+
+
+Javascript Button
+-----------------
+
+Navigate: ``Setup`` > ``Create`` > ``Objects`` > ``Patient`` > ``New Action``
+
+Create a custom button to call into the APEX code
+
+:Label: Run Eligibility Check
+:Name: Run_Eligibility_Check
+:Behavior: Execute JavaScript
+:OnClick Javascript: See below
+
+
+.. code-block:: javascript
+
+  {!REQUIRESCRIPT("/soap/ajax/25.0/connection.js")} 
+  {!REQUIRESCRIPT("/soap/ajax/25.0/apex.js")} 
+  var result = sforce.apex.execute("Eligibility","runEligibilityCheck",{}); 
+  alert(result); 
+  window.location.reload(); 
+  sforce.debug.trace=true;
+
+
+Navigate: ``Setup`` > ``Create`` > ``Objects`` > ``Patient`` > ``[Edit] Patient Layout`` > ``Buttons``
+
+Add the ``Run Eligibility Check`` button to the ``Custom Buttons`` section on the layout.  While in the Layout, feel free to arrange the fields.
+
+
+Create A Patient Record
+-----------------------
+
+Navigate: ``Patients`` > ``New``
+
+:Patient ID: 1234567890
+:First Name: John
+:Last Name: Doe 
+:Birth Date:  1/1/1970
+:Payer: MOCKPAYER
+:Member ID: 0987654321
+
+
+Make An Eligibility Request
+---------------------------
+
+After creating the patient, click the ``Run Eligibility Request`` button.
 
 
 License
@@ -45,5 +105,6 @@ Copyright (c) 2016 PokitDok, Inc.  See LICENSE_ for details.
 
 .. _documentation: https://platform.pokitdok.com/documentation/v4/?apex#
 .. _issues: https://github.com/pokitdok/pokitdok-apex/issues
+.. _example: https://github.com/pokitdok/pokitdok-apex/tree/dev/example
 .. _LICENSE: LICENSE.txt
 

--- a/example/README.rst
+++ b/example/README.rst
@@ -1,5 +1,5 @@
-APEX Reference Implementation
-=============================
+Salesforce Apex Reference Implementation
+========================================
 
 Scenario
 --------
@@ -66,13 +66,13 @@ Create a custom button to call into the APEX code
 
 .. code-block:: javascript
 
-  {!REQUIRESCRIPT("/soap/ajax/25.0/connection.js")} 
-  {!REQUIRESCRIPT("/soap/ajax/25.0/apex.js")} 
-  var result = sforce.apex.execute("Eligibility","runEligibilityCheck",{}); 
-  alert(result); 
-  window.location.reload(); 
+  {!REQUIRESCRIPT("/soap/ajax/25.0/connection.js")}
+  {!REQUIRESCRIPT("/soap/ajax/25.0/apex.js")}
+  var patientId='{!Patient__c.Name}';
+  var result = sforce.apex.execute("Eligibility","runEligibilityCheck",{patientID: patientId});
+  alert(result);
+  window.location.reload();
   sforce.debug.trace=true;
-
 
 Navigate: ``Setup`` > ``Create`` > ``Objects`` > ``Patient`` > ``[Edit] Patient Layout`` > ``Buttons``
 
@@ -95,7 +95,11 @@ Navigate: ``Patients`` > ``New``
 Make An Eligibility Request
 ---------------------------
 
-After creating the patient, click the ``Run Eligibility Request`` button.
+After creating the patient, click the ``Run Eligibility Request`` button.  If successful, you will see a message stating something akin to:
+
+    *The patient's coverage is active and began on 2/15/2013*
+
+You should also see the ``Active Coverage`` and ``Plan Begin Date`` fields update.
 
 
 License

--- a/example/README.rst
+++ b/example/README.rst
@@ -1,0 +1,49 @@
+PokitDok Platform API Client for Salesforce APEX 
+=======================================
+
+Resources
+---------
+
+Please see the documentation_ for detailed information on all of the PokitDok Platform APIs.
+The documentation includes APEX client examples for each of the implemented APIs.
+
+Report API client issues_ on GitHub
+
+
+Quick start
+-----------
+
+.. code-block:: apex
+
+    // Instantiate a PokitDokAPIClient with your credentials
+    PokitDokAPIClient pokitdok = new PokitDokAPIClient('<CLIENT_ID>', '<CLIENT_SECRET>');
+
+    // Create an eligibility request payload
+    Map<String,String> member = new Map<String,String>();
+    member.put('birth_date', '1970-01-01');
+    member.put('first_name', 'John');
+    member.put('last_name', 'Smith');
+    member.put('id', '3141592653');
+    eligibilityRequest.put('member',member);
+
+    Map<String,String> provider = new Map<String,String>();
+    provider.put('first_name', 'Jane');
+    provider.put('last_name', 'Doe');
+    provider.put('npi', '1467560003');
+    eligibilityRequest.put('provider',provider);
+
+    eligibilityRequest.put('trading_partner_id','MOCKPAYER');
+        
+    // Make the call to the eligibility API.  The response is serialized JSON.
+    String eligibilityResponse = pokitdok.eligibility(JSON.serialize(eligibilityRequest));
+
+
+License
+-------
+
+Copyright (c) 2016 PokitDok, Inc.  See LICENSE_ for details.
+
+.. _documentation: https://platform.pokitdok.com/documentation/v4/?apex#
+.. _issues: https://github.com/pokitdok/pokitdok-apex/issues
+.. _LICENSE: LICENSE.txt
+

--- a/src/PokitDokAPIClient.apxc
+++ b/src/PokitDokAPIClient.apxc
@@ -1,0 +1,149 @@
+/**
+ * The PokitDokAPIClient is an object wrapper that makes requests to the PokitDok
+ * Platform APIs on behalf of the calling APEX code.  
+ * 
+ * The PokitDokAPIClient simplifies authorization and access to the APIs by encapsulating
+ * the OAuth dance.  The Client ID and Client Secret credentials passed into the 
+ * constructor are obtained by signing up for free at https://platform.pokitdok.com.
+ * 
+ * Each method that implments a PokitDok Platform API call takes in a serialized JSON
+ * request payload and returns a serialized response payload.  The calling code will
+ * both generate the proper serialized JSON String to send to the wrapped API method,
+ * as well as parse the serialized JSON String that is returned.
+ * 
+ * The endpoint for https://platform.pokitdok.com needs to be set up as a Remote Site.
+ * For reference, see:
+ * https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_callouts_remote_site_settings.htm
+ */
+public class PokitDokAPIClient {   
+    // URL endpoints
+    public static final String POKITDOK_BASE_URL = 'https://platform.pokitdok.com';
+    public static final String AUTHENTICATION_ENDPOINT = '/oauth2/token';
+    public static final String ELIGIBILITY_ENDPOINT = '/api/v4/eligibility/';
+    
+    // The OAuth credentials
+    private String clientID;
+    private String clientSecret;
+    
+    /**
+     * The constructor expects valid OAuth credentials.
+     * 
+     * @param the id is Client ID for the PokitDok Platform App
+     * @param the secret is Client Secret for the PokitDok Platform App
+     */
+    public PokitDokAPIClient(String id, String secret) {
+        clientID = id;
+        clientSecret = secret;
+    }
+    
+    /**
+     * The authenticate method encapsulates OAuth requests and returns the session access
+     * token to be used by subsequent API calls.
+     * 
+     * Note:  The present version will retrieve a fresh access token for every API request.
+     * Future versions will cache the access token in local storage for usage.  If the 
+     * status code of the API call is 401, only then will the access token be requested.
+     * 
+     * @return the access token if authenticated; an empty String otherwise
+     */
+    public String authenticate() {
+        Http http = new Http();
+        HttpRequest request = new HttpRequest();
+        HTTPResponse response = new HttpResponse();
+        
+        // Set up the request to the PokitDok Platform OAuth endpoint
+        request.setEndpoint(POKITDOK_BASE_URL + AUTHENTICATION_ENDPOINT);
+        request.setMethod('POST');        
+        
+        // Encode the Client ID / Client Secret combination and dump it in the header       
+        Blob clientCredentials = Blob.valueOf(clientID + ':' + clientSecret);
+        String encodedclientCredentials = EncodingUtil.base64Encode(clientCredentials);        
+        String authorizationHeader = 'Basic ' + encodedclientCredentials;
+        request.setHeader('Authorization', authorizationHeader);        
+        request.setHeader('Content-Type', 'application/x-www-form-urlencoded');
+        
+        String body = 'grant_type=client_credentials';		        
+        request.setBody(body);
+        
+        // Make the request to obtain the access token
+        try {
+            response = http.send(request);
+        } catch(System.CalloutException e) {
+            System.debug(Logginglevel.ERROR, 
+                         '[PokitDokAPIClient]  Error Message: ' + e);
+            System.debug(Logginglevel.ERROR, 
+                         '[PokitDokAPIClient]  POST Request: ' + request.getBody());
+        }
+        
+        // Dig out the access token from the response payload
+        JSONParser parser = JSON.createParser(response.getBody());
+        while (parser.nextToken() != null) {
+            if ((parser.getCurrentToken() == JSONToken.FIELD_NAME) && 
+                (parser.getText() == 'access_token')) {
+                    parser.nextToken();
+                    String sessionToken = parser.getText();
+                    return sessionToken;                    
+                }
+        }
+        
+        return '';
+    }
+    
+    /**
+     * The post method implements the POST method.
+     * 
+     * @param the APIEndpoint is the URL of the target API endpoint
+     * @param the requestPayload is the serialized JSON request
+     * @return the serialized JSON response
+     */
+    public String post(String APIEndpoint, String requestPayload) {
+        Http http = new Http();
+        HttpRequest request = new HttpRequest();
+        HTTPResponse response = new HttpResponse();
+        
+        // Authenticate before making the API call
+        String sessionToken = authenticate();        
+        if (sessionToken != '') {
+            // Set up the request to the PokitDok Platform POST endpoint
+            request.setEndpoint(APIEndpoint);
+            request.setMethod('POST');
+            request.setHeader('Authorization', 'Bearer ' + sessionToken);
+            request.setHeader('Content-Type', 'application/json');
+            request.setBody(requestPayload);
+            
+            try {
+                response = http.send(request);
+            } catch(System.CalloutException e) {
+                System.debug(Logginglevel.ERROR, 
+                             '[PokitDokAPIClient]  Error Message: ' + e);
+                System.debug(Logginglevel.ERROR, 
+                             '[PokitDokAPIClient]  POST Request: ' + request.getBody());
+                return '{ "error": "Unable to process your eligibility at this time.  ' + 
+                    'The origianl request has been logged" }';
+            }
+            
+            // Log bad responses
+            if (response.getStatusCode() != 200) {
+                System.debug(Logginglevel.ERROR, 
+                             '[PokitDokAPIClient]  POST Request: ' + request.getBody());
+                System.debug(Logginglevel.ERROR, 
+                             '[PokitDokAPIClient]  POST Response: ' + response.getBody());
+            }
+        }
+        
+        return response.getBody();        
+    }
+    
+    /**
+     * The eligibility method performs an eligibility check given a patient's PHI, a
+     * provider's information and the ID of the insurer.
+     * 
+     * @param the serializedJSON is request payload
+     * @return the serialized JSON response
+     */
+    public String eligibility(String serializedJSON){        
+        // Set up the request to the PokitDok Platform Eligibility endpoint        
+        String endpoint = POKITDOK_BASE_URL + ELIGIBILITY_ENDPOINT;
+        return post(endpoint, serializedJSON);
+    }
+}

--- a/src/PokitDokAPIClient.apxc
+++ b/src/PokitDokAPIClient.apxc
@@ -14,12 +14,22 @@
  * The endpoint for https://platform.pokitdok.com needs to be set up as a Remote Site.
  * For reference, see:
  * https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_callouts_remote_site_settings.htm
+ * 
+ * Copyright (C) 2016, All Rights Reserved, PokitDok, Inc.
+ * https://platform.pokitdok.com
+ *
+ * Please see the License.txt file for more information.
+ * All other rights reserved.
  */
 public class PokitDokAPIClient {   
+    
     // URL endpoints
     public static final String POKITDOK_BASE_URL = 'https://platform.pokitdok.com';
     public static final String AUTHENTICATION_ENDPOINT = '/oauth2/token';
     public static final String ELIGIBILITY_ENDPOINT = '/api/v4/eligibility/';
+    
+    public static final String CALLOUT_EXCEPTION_MESSAGE = 'Unable to process your ' +
+        'request at this time. The original request has been logged';
     
     // The OAuth credentials
     private String clientID;
@@ -118,8 +128,7 @@ public class PokitDokAPIClient {
                              '[PokitDokAPIClient]  Error Message: ' + e);
                 System.debug(Logginglevel.ERROR, 
                              '[PokitDokAPIClient]  POST Request: ' + request.getBody());
-                return '{ "error": "Unable to process your eligibility at this time.  ' + 
-                    'The origianl request has been logged" }';
+                return '{ "error": ' + CALLOUT_EXCEPTION_MESSAGE + ' }';
             }
             
             // Log bad responses

--- a/src/PokitDokAPIClient.apxc
+++ b/src/PokitDokAPIClient.apxc
@@ -21,7 +21,7 @@
  * Please see the License.txt file for more information.
  * All other rights reserved.
  */
-public class PokitDokAPIClient {   
+public class PokitDokAPIClient {
     
     // URL endpoints
     public static final String POKITDOK_BASE_URL = 'https://platform.pokitdok.com';
@@ -31,9 +31,11 @@ public class PokitDokAPIClient {
     public static final String CALLOUT_EXCEPTION_MESSAGE = 'Unable to process your ' +
         'request at this time. The original request has been logged';
     
-    // The OAuth credentials
+    // Session management
     private String clientID;
     private String clientSecret;
+    public Boolean autoRenewSession { get; set; }
+    public PokitDokSessionCacheManager sessionManager = null;
     
     /**
      * The constructor expects valid OAuth credentials.
@@ -41,22 +43,58 @@ public class PokitDokAPIClient {
      * @param the id is Client ID for the PokitDok Platform App
      * @param the secret is Client Secret for the PokitDok Platform App
      */
-    public PokitDokAPIClient(String id, String secret) {
-        clientID = id;
-        clientSecret = secret;
+    public PokitDokAPIClient(String clientID, String clientSecret) {
+        this.clientID = clientID;
+        this.clientSecret = clientSecret;
+        this.autoRenewSession = false;
+    }
+
+    /**
+     * The constructor expects valid OAuth credentials and a flag to determine if the
+     * access token should be cached and renewed when it expires.
+     * 
+     * @param the id is Client ID for the PokitDok Platform App
+     * @param the secret is Client Secret for the PokitDok Platform App
+     * @param should the session access token be cached and the session be renewed
+     *        after the token expires
+     */
+    public PokitDokAPIClient(String clientID, String clientSecret, Boolean autoRenewSession) {
+        this.clientID = clientID;
+        this.clientSecret = clientSecret;
+        this.autoRenewSession = autoRenewSession;
+        
+        if (autoRenewSession) {
+            sessionManager = new PokitDokSessionCacheManager(clientID);
+
+            // Make sure the Platform Cache is set up properly
+            if (!sessionManager.cacheEnabled) {
+                this.autoRenewSession = false;
+            }
+        }
     }
     
     /**
      * The authenticate method encapsulates OAuth requests and returns the session access
      * token to be used by subsequent API calls.
      * 
-     * Note:  The present version will retrieve a fresh access token for every API request.
-     * Future versions will cache the access token in local storage for usage.  If the 
-     * status code of the API call is 401, only then will the access token be requested.
+     * Authentication works one of two ways.  You can exercise the option to utilize the
+     * Salesforce Platform Cache to store the session access token for future requests,
+     * or you can authenticate with each request.  Caching is preferred if possible.
      * 
-     * @return the access token if authenticated; an empty String otherwise
+     * @return the session access token if authenticated; an empty String otherwise
      */
     public String authenticate() {
+        String accessToken = '';
+        
+        // Check the cache for the access token
+        if (autoRenewSession) {
+            accessToken = sessionManager.getToken();
+            if (accessToken != null) {
+                return accessToken;
+            }
+        }
+        
+        // Retrieve the access token
         Http http = new Http();
         HttpRequest request = new HttpRequest();
         HTTPResponse response = new HttpResponse();
@@ -79,10 +117,8 @@ public class PokitDokAPIClient {
         try {
             response = http.send(request);
         } catch(System.CalloutException e) {
-            System.debug(Logginglevel.ERROR, 
-                         '[PokitDokAPIClient]  Error Message: ' + e);
-            System.debug(Logginglevel.ERROR, 
-                         '[PokitDokAPIClient]  POST Request: ' + request.getBody());
+            processCalloutException(e, request);
+            return '';
         }
         
         // Dig out the access token from the response payload
@@ -90,12 +126,18 @@ public class PokitDokAPIClient {
         while (parser.nextToken() != null) {
             if ((parser.getCurrentToken() == JSONToken.FIELD_NAME) && 
                 (parser.getText() == 'access_token')) {
-                    parser.nextToken();
-                    String sessionToken = parser.getText();
-                    return sessionToken;                    
+                parser.nextToken();
+                accessToken = parser.getText();
+
+                // Cache the token for future requests
+                if (autoRenewSession) {
+                    sessionManager.putToken(accessToken);
                 }
+                
+                return accessToken;                    
+            }
         }
-        
+
         return '';
     }
     
@@ -112,26 +154,38 @@ public class PokitDokAPIClient {
         HTTPResponse response = new HttpResponse();
         
         // Authenticate before making the API call
-        String sessionToken = authenticate();        
-        if (sessionToken != '') {
+        String accessToken = authenticate();        
+        if (accessToken != '') {
             // Set up the request to the PokitDok Platform POST endpoint
             request.setEndpoint(APIEndpoint);
             request.setMethod('POST');
-            request.setHeader('Authorization', 'Bearer ' + sessionToken);
+            request.setHeader('Authorization', 'Bearer ' + accessToken);
             request.setHeader('Content-Type', 'application/json');
             request.setBody(requestPayload);
             
             try {
                 response = http.send(request);
             } catch(System.CalloutException e) {
-                System.debug(Logginglevel.ERROR, 
-                             '[PokitDokAPIClient]  Error Message: ' + e);
-                System.debug(Logginglevel.ERROR, 
-                             '[PokitDokAPIClient]  POST Request: ' + request.getBody());
-                return '{ "error": ' + CALLOUT_EXCEPTION_MESSAGE + ' }';
+                return processCalloutException(e, request);
             }
             
-            // Log bad responses
+            // If the session has expired, flush the cache, renew the access token and
+            // replay the transaction
+            if (response.getStatusCode() == 401) {
+                if (sessionManager.removeToken()) {
+                    accessToken = authenticate();
+                    if (accessToken != '') {
+                        request.setHeader('Authorization', 'Bearer ' + accessToken);
+                        try {
+                            response = http.send(request);
+                        } catch(System.CalloutException e) {
+                            return processCalloutException(e, request);
+                        }
+                    }
+                }
+            }
+            
+            // Log bad responses            
             if (response.getStatusCode() != 200) {
                 System.debug(Logginglevel.ERROR, 
                              '[PokitDokAPIClient]  POST Request: ' + request.getBody());
@@ -155,4 +209,22 @@ public class PokitDokAPIClient {
         String endpoint = POKITDOK_BASE_URL + ELIGIBILITY_ENDPOINT;
         return post(endpoint, serializedJSON);
     }
+    
+    /**
+     * The processCalloutException method handles the event of a CalloutException being
+     * thrown.  It spools out the exception message to the error log
+     * 
+     * @param the thrown CalloutException
+     * @param the request that caused the exception to be thrown
+     * @return the error message to be consumed programatically
+     */
+    private String processCalloutException(System.CalloutException e, 
+                                           HTTPRequest request) {
+        System.debug(Logginglevel.ERROR, 
+                     '[PokitDokAPIClient.processCalloutException]  Error Message: ' + e);
+        System.debug(Logginglevel.ERROR, 
+                     '[PokitDokAPIClient.processCalloutException]  POST Request: ' + request.getBody());
+        return '{ "error": ' + CALLOUT_EXCEPTION_MESSAGE + ' }';        
+    }
 }
+

--- a/src/PokitDokSessionCacheManager.apxc
+++ b/src/PokitDokSessionCacheManager.apxc
@@ -1,0 +1,111 @@
+/**
+ * The PokitDokSessionCacheManager class manages the storage and retrieval of
+ * the OAuth access token for session management with the PokitDok Platform.
+ * It employs the Salesforce Platform Cache, a new feature available to 
+ * Enterprise, Unlimited, and Performance editions.  This Cache Manager uses
+ * the Org Cache which allows for the storage of the session access token for
+ * users across the organization.
+ *
+ * For more information, see: https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_cache_namespace_overview.htm
+ * 
+ * Copyright (C) 2016, All Rights Reserved, PokitDok, Inc.
+ * https://platform.pokitdok.com
+ *
+ * Please see the License.txt file for more information.
+ * All other rights reserved.
+ */
+public class PokitDokSessionCacheManager {
+    
+    // The PokitDok Platform session is only alive for an hour, so set the
+    // cache time to live appropriately
+    private final integer TIME_TO_LIVE = 3600;
+    
+    // A flag for calling code to determine if the Platform Cache is available
+    // for usage
+    public Boolean cacheEnabled { get; set; }
+    
+    // The default cache partition
+    private Cache.OrgPartition cachePartition = null;
+        
+    // The cache key: 'PokitDokAccessToken' + clientID
+    private String accessTokenCacheKey;
+        
+    /**
+     * The constructor takes in the Client ID.  This allows organizations that
+     * have multiple PokitDok Platform Apps to each store their own session access
+     * token in the cache.
+     *
+     * @param the Client ID of the PokitDok Platform App.
+     */
+    public PokitDokSessionCacheManager(String clientID) {
+        this.cacheEnabled = false;
+        
+        // See if a cache partition is available.  If it is, set the flag and define
+        // the cache key
+        String defaultPartition = Cache.Org.getName();
+        if (defaultPartition != '') {
+            cacheEnabled = true;
+            cachePartition = Cache.Org.getPartition(defaultPartition);
+            accessTokenCacheKey = 'PokitDokAccessToken' + clientID;
+        }
+    }
+
+    /**
+     * The getCacheStatistics method provides some diagnostics around the cache.
+     * This feature is apparently new in Salesforce and this data might be useful
+     * to inspect.
+     * 
+     * @return a map of data about the state of the cache
+     */
+    public Map<String, Object> getCacheStatistics() {
+        Map<String, Object> cacheStatistics = new Map<String, Object>();
+        cacheStatistics.put('default_partition', Cache.Org.getName());
+        cacheStatistics.put('capacity', Cache.Org.getCapacity());
+        cacheStatistics.put('number_of_keys', Cache.Org.getNumKeys());
+        cacheStatistics.put('keys', Cache.Org.getKeys());
+        cacheStatistics.put('miss_rate', Cache.Org.getMissRate());
+        cacheStatistics.put('average_get_time', Cache.Org.getAvgGetTime());
+        cacheStatistics.put('max_get_time', Cache.Org.getMaxGetTime());
+        return cacheStatistics;
+    }
+    
+    /**
+     * The getToken method abstracts the retrieval of the session access token.
+     * 
+     * @return the token from cache if available
+     */
+    public String getToken() {
+        if (!cacheEnabled) {
+            return null;
+        }
+                
+        return (String) cachePartition.get(accessTokenCacheKey);
+    }
+
+    /**
+     * The putToken method abstracts the storage of the session access token.
+     * 
+     * @param the value of the session access token to cache
+     */
+    public void putToken(String value) {
+        if (!cacheEnabled) {
+            return;
+        }
+
+        cachePartition.put(accessTokenCacheKey, value, TIME_TO_LIVE, Cache.Visibility.ALL, false);
+    }
+
+    /**
+     * The removeToken method abstracts the removal of the session access token.
+     *
+     * @return if the removal was successful
+     */
+    public Boolean removeToken() {
+        if (!cacheEnabled) {
+            return false;
+        }
+        
+        return cachePartition.remove(accessTokenCacheKey);        
+    }
+}
+

--- a/test/PokitDokAPIClientTest.apxc
+++ b/test/PokitDokAPIClientTest.apxc
@@ -13,6 +13,31 @@
 @isTest
 public class PokitDokAPIClientTest {
    
+    public final static String TEST_CLIENT_ID = 'ClientID';
+    public final static String TEST_CLIENT_SECRET = 'ClientSecret';
+    
+    /**
+     * The testAutoRenewalSetting method tests how the autoRenewSession flag is set in
+     * the constructors. 
+     */
+    @isTest 
+    static void testAutoRenewalSetting() {
+        // Verify the Platform Cache Partition won't be used
+        PokitDokAPIClient pokitDok = new PokitDokAPIClient(TEST_CLIENT_ID, TEST_CLIENT_SECRET);
+        Boolean autoRenewSession = pokitDok.autoRenewSession;        
+        System.assertEquals(autoRenewSession, false);
+        
+        pokitDok = new PokitDokAPIClient(TEST_CLIENT_ID, TEST_CLIENT_SECRET, false);
+        autoRenewSession = pokitDok.autoRenewSession;
+        System.assertEquals(autoRenewSession, false);
+        
+        // Verify the Platform Cache Partition will be used
+        pokitDok = new PokitDokAPIClient(TEST_CLIENT_ID, TEST_CLIENT_SECRET, true);
+        autoRenewSession = pokitDok.autoRenewSession;        
+        System.assertEquals(autoRenewSession, true);
+    }
+    
+    
     /**
      * The testAuthentication method tests that the access token is on the response.
      * Since this test does not actually go across the wire, thge actual Client ID /
@@ -21,8 +46,10 @@ public class PokitDokAPIClientTest {
     @isTest 
     static void testAuthentication() {
         // Set mock callout class 
-        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator(false, false));        
-        PokitDokAPIClient pokitDok = new PokitDokAPIClient('clientID', 'clientSecret');
+        Test.setMock(HttpCalloutMock.class, 
+	             new PokitDokMockResponseGenerator(false, false, false));
+        PokitDokAPIClient pokitDok = new PokitDokAPIClient(TEST_CLIENT_ID, TEST_CLIENT_SECRET, 
+                                                           true);
         String session_token = pokitDok.authenticate();
         
         // Verify the session access token has been set
@@ -52,8 +79,10 @@ public class PokitDokAPIClientTest {
      */    
     @isTest static void testEligibility() {
         // Set mock callout class 
-        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator(false, false));        
-        PokitDokAPIClient pokitDok = new PokitDokAPIClient('clientId', 'clientSecret');
+        Test.setMock(HttpCalloutMock.class, 
+                     new PokitDokMockResponseGenerator(false, false, false));        
+        PokitDokAPIClient pokitDok = new PokitDokAPIClient(TEST_CLIENT_ID, TEST_CLIENT_SECRET, 
+                                                           true);
         
         // Create a test JSON request
         Map<String,Object> eligibilityRequest = new Map<String,Object>();
@@ -100,15 +129,50 @@ public class PokitDokAPIClientTest {
     }
 
     /**
+     * The testCalloutException method tests a borked HTTP connection.  The client 
+     * will return a manufactured JSON message will include a JSON field called 
+     * "error".
+     */
+    @isTest 
+    static void testCalloutException() {
+        // Set mock callout class 
+        Test.setMock(HttpCalloutMock.class, 
+                     new PokitDokMockResponseGenerator(true, false, false));        
+        PokitDokAPIClient pokitDok = new PokitDokAPIClient(TEST_CLIENT_ID, TEST_CLIENT_SECRET, 
+                                                           false);        
+
+        // Create an empty test JSON request
+        Map<String,Object> eligibilityRequest = new Map<String,Object>();
+        String eligibilityResponse = pokitDok.eligibility(JSON.serialize(eligibilityRequest));
+        
+        // Verify there is an error message in the JSON response
+        System.assert(eligibilityResponse != null);
+        String expectedCalloutExceptionMessage = '';
+        
+        JSONParser parser = JSON.createParser(eligibilityResponse);
+        while (parser.nextToken() != null) {
+            if ((parser.getCurrentToken() == JSONToken.FIELD_NAME) && 
+                (parser.getText() == 'error')) {
+                parser.nextToken();
+                expectedCalloutExceptionMessage = parser.getText();
+                System.assertEquals(expectedCalloutExceptionMessage, 
+                                    PokitDokAPIClient.CALLOUT_EXCEPTION_MESSAGE);
+            }
+        }
+    }
+    
+    /**
      * The testUnsuccessfulResponse method tests an HTTP response with a status code
-     * other than 200.  The client will simply return the error message it received
-     * from the APIs.  The message will include a JSON field called "errors".
+     * other than 200 and 401.  The client will simply return the error message it
+     * received from the APIs.  The message will include a JSON field called "errors".
      */
     @isTest 
     static void testUnsuccessfulResponse() {
         // Set mock callout class 
-        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator(false, true));        
-        PokitDokAPIClient pokitDok = new PokitDokAPIClient('clientID', 'clientSecret');
+        Test.setMock(HttpCalloutMock.class, 
+                     new PokitDokMockResponseGenerator(false, true, false));        
+        PokitDokAPIClient pokitDok = new PokitDokAPIClient(TEST_CLIENT_ID, TEST_CLIENT_SECRET, 
+	                                                       false);
 
         // Create an empty test JSON request
         Map<String,Object> eligibilityRequest = new Map<String,Object>();
@@ -129,35 +193,47 @@ public class PokitDokAPIClientTest {
             }
         }
     }
-    
+
     /**
-     * The testCalloutException method tests a borked HTTP connection.  The client 
-     * will return a manufactured JSON message will include a JSON field called 
-     * "error".
+     * The testSessionExpired method tests an HTTP response with a status code of 401.
+     * The client will try to replay the request after reauthenticating.  
+     * This is almost a complete.  Warm the cache with a fake session token to clear
+     * first call to authenticate().  It will come back with a token from the cache.
+     * When the actual request is made a 401 is returned, and the cache will be flushed
+     * and the authenticate() will be called again.  In the real world, this will
+     * succeed, but in this test, the second authenticate API call will also return
+     * a 401 response as well, so technically the second transaction is not replayed.
      */
     @isTest 
-    static void testCalloutException() {
+    static void testSessionExpired() {
+        // Warm the cache with a fake expired session token
+        PokitDokSessionCacheManager sessionManager = new PokitDokSessionCacheManager(TEST_CLIENT_ID);
+        sessionManager.putToken('EXPIRED_TOKEN');
+
         // Set mock callout class 
-        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator(true, false));        
-        PokitDokAPIClient pokitDok = new PokitDokAPIClient('clientID', 'clientSecret');
+        Test.setMock(HttpCalloutMock.class, 
+                     new PokitDokMockResponseGenerator(false, false, true));
+        PokitDokAPIClient pokitDok = new PokitDokAPIClient(TEST_CLIENT_ID, TEST_CLIENT_SECRET, 
+                                                           true);        
 
         // Create an empty test JSON request
         Map<String,Object> eligibilityRequest = new Map<String,Object>();
         String eligibilityResponse = pokitDok.eligibility(JSON.serialize(eligibilityRequest));
-        
+                
         // Verify there is an error message in the JSON response
         System.assert(eligibilityResponse != null);
-        String expectedCalloutExceptionMessage = '';
+        String expectedUnsuccessfulMessage = '';
         
         JSONParser parser = JSON.createParser(eligibilityResponse);
         while (parser.nextToken() != null) {
             if ((parser.getCurrentToken() == JSONToken.FIELD_NAME) && 
-                (parser.getText() == 'error')) {
+                (parser.getText() == 'errors')) {
                 parser.nextToken();
-                expectedCalloutExceptionMessage = parser.getText();
-                System.assertEquals(expectedCalloutExceptionMessage, 
-                                    PokitDokAPIClient.CALLOUT_EXCEPTION_MESSAGE);
+                expectedUnsuccessfulMessage = parser.getText();
+                System.assertEquals(expectedUnsuccessfulMessage, 
+                                    PokitDokMockResponseGenerator.SESSION_EXPIRED_MESSAGE);
             }
         }
-    }    
+    } 
 }
+

--- a/test/PokitDokAPIClientTest.apxc
+++ b/test/PokitDokAPIClientTest.apxc
@@ -3,10 +3,16 @@
  * Platform.  Since APEX test classes are not permitted to access remote sites, the
  * responses from the method calls are all mocked.  The mocked responses are produced
  * by the PokitDokMockResponseGenerator.
+ * 
+ * Copyright (C) 2016, All Rights Reserved, PokitDok, Inc.
+ * https://platform.pokitdok.com
+ *
+ * Please see the License.txt file for more information.
+ * All other rights reserved.
  */
 @isTest
 public class PokitDokAPIClientTest {
-    
+   
     /**
      * The testAuthentication method tests that the access token is on the response.
      * Since this test does not actually go across the wire, thge actual Client ID /
@@ -15,7 +21,7 @@ public class PokitDokAPIClientTest {
     @isTest 
     static void testAuthentication() {
         // Set mock callout class 
-        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator());        
+        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator(false, false));        
         PokitDokAPIClient pokitDok = new PokitDokAPIClient('clientID', 'clientSecret');
         String session_token = pokitDok.authenticate();
         
@@ -46,7 +52,7 @@ public class PokitDokAPIClientTest {
      */    
     @isTest static void testEligibility() {
         // Set mock callout class 
-        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator());        
+        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator(false, false));        
         PokitDokAPIClient pokitDok = new PokitDokAPIClient('clientId', 'clientSecret');
         
         // Create a test JSON request
@@ -92,4 +98,66 @@ public class PokitDokAPIClientTest {
             }
         }        
     }
+
+    /**
+     * The testUnsuccessfulResponse method tests an HTTP response with a status code
+     * other than 200.  The client will simply return the error message it received
+     * from the APIs.  The message will include a JSON field called "errors".
+     */
+    @isTest 
+    static void testUnsuccessfulResponse() {
+        // Set mock callout class 
+        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator(false, true));        
+        PokitDokAPIClient pokitDok = new PokitDokAPIClient('clientID', 'clientSecret');
+
+        // Create an empty test JSON request
+        Map<String,Object> eligibilityRequest = new Map<String,Object>();
+        String eligibilityResponse = pokitDok.eligibility(JSON.serialize(eligibilityRequest));
+        
+        // Verify there is an error message in the JSON response
+        System.assert(eligibilityResponse != null);
+        String expectedUnsuccessfulMessage = '';
+        
+        JSONParser parser = JSON.createParser(eligibilityResponse);
+        while (parser.nextToken() != null) {
+            if ((parser.getCurrentToken() == JSONToken.FIELD_NAME) && 
+                (parser.getText() == 'errors')) {
+                parser.nextToken();
+                expectedUnsuccessfulMessage = parser.getText();
+                System.assertEquals(expectedUnsuccessfulMessage, 
+                                    PokitDokMockResponseGenerator.UNSUCCESSFUL_MESSAGE);
+            }
+        }
+    }
+    
+    /**
+     * The testCalloutException method tests a borked HTTP connection.  The client 
+     * will return a manufactured JSON message will include a JSON field called 
+     * "error".
+     */
+    @isTest 
+    static void testCalloutException() {
+        // Set mock callout class 
+        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator(true, false));        
+        PokitDokAPIClient pokitDok = new PokitDokAPIClient('clientID', 'clientSecret');
+
+        // Create an empty test JSON request
+        Map<String,Object> eligibilityRequest = new Map<String,Object>();
+        String eligibilityResponse = pokitDok.eligibility(JSON.serialize(eligibilityRequest));
+        
+        // Verify there is an error message in the JSON response
+        System.assert(eligibilityResponse != null);
+        String expectedCalloutExceptionMessage = '';
+        
+        JSONParser parser = JSON.createParser(eligibilityResponse);
+        while (parser.nextToken() != null) {
+            if ((parser.getCurrentToken() == JSONToken.FIELD_NAME) && 
+                (parser.getText() == 'error')) {
+                parser.nextToken();
+                expectedCalloutExceptionMessage = parser.getText();
+                System.assertEquals(expectedCalloutExceptionMessage, 
+                                    PokitDokAPIClient.CALLOUT_EXCEPTION_MESSAGE);
+            }
+        }
+    }    
 }

--- a/test/PokitDokAPIClientTest.apxc
+++ b/test/PokitDokAPIClientTest.apxc
@@ -1,0 +1,95 @@
+/**
+ * The PokitDokAPIClientTest class tests out the implmented API calls of the PokitDok
+ * Platform.  Since APEX test classes are not permitted to access remote sites, the
+ * responses from the method calls are all mocked.  The mocked responses are produced
+ * by the PokitDokMockResponseGenerator.
+ */
+@isTest
+public class PokitDokAPIClientTest {
+    
+    /**
+     * The testAuthentication method tests that the access token is on the response.
+     * Since this test does not actually go across the wire, thge actual Client ID /
+     * Client Secret credentials are _not_ required.
+     */
+    @isTest 
+    static void testAuthentication() {
+        // Set mock callout class 
+        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator());        
+        PokitDokAPIClient pokitDok = new PokitDokAPIClient('clientID', 'clientSecret');
+        String session_token = pokitDok.authenticate();
+        
+        // Verify the session access token has been set
+        System.assertEquals(session_token, PokitDokMockResponseGenerator.ACCESS_TOKEN);
+    }
+
+    /**
+     * The testEligibility method tests that the Activity ID and Correlation ID are on
+     * the response.  Since this test does not actually go across the wire, thge actual 
+     * Client ID / Client Secret credentials are _not_ required.  The JSON payload should
+     * look like this:
+     * 
+     * {
+     *     "member": {
+     *         "birth_date": "1970-01-01",
+     *         "first_name": "John",
+     *         "last_name": "Smith",
+     *         "id": "3141592653"
+     *     },
+     *     "provider": {
+     *         "first_name": "Jane",
+     *         "last_name": "Doe",
+     *         "npi": "1467560003"
+     *     },
+     *     "trading_partner_id": "MOCKPAYER"
+     * }
+     */    
+    @isTest static void testEligibility() {
+        // Set mock callout class 
+        Test.setMock(HttpCalloutMock.class, new PokitDokMockResponseGenerator());        
+        PokitDokAPIClient pokitDok = new PokitDokAPIClient('clientId', 'clientSecret');
+        
+        // Create a test JSON request
+        Map<String,Object> eligibilityRequest = new Map<String,Object>();
+        
+        Map<String,String> member = new Map<String,String>();
+        member.put('birth_date', '1970-01-01');
+        member.put('first_name', 'John');
+        member.put('last_name', 'Smith');
+        member.put('id', '3141592653');
+        eligibilityRequest.put('member',member);
+        
+        Map<String,String> provider = new Map<String,String>();
+        provider.put('first_name', 'Jane');
+        provider.put('last_name', 'Doe');
+        provider.put('npi', '1467560003');
+        eligibilityRequest.put('provider',provider);
+        
+        eligibilityRequest.put('trading_partner_id','MOCKPAYER');        
+        
+        String eligibilityResponse = pokitDok.eligibility(JSON.serialize(eligibilityRequest));
+        
+        // Verify just a few fields in the JSON response
+        System.assert(eligibilityResponse != null);
+        String expectedActivityID = '';
+        String expectedCorrelationID = '';
+        
+        JSONParser parser = JSON.createParser(eligibilityResponse);
+        while (parser.nextToken() != null) {
+            if ((parser.getCurrentToken() == JSONToken.FIELD_NAME) && 
+                (parser.getText() == 'activity_id')) {
+                parser.nextToken();
+                expectedActivityID = parser.getText();
+                System.assertEquals(expectedActivityID, 
+                                    PokitDokMockResponseGenerator.ACTIVITY_ID);
+            }
+            if ((parser.getCurrentToken() == JSONToken.FIELD_NAME) && 
+                (parser.getText() == 'correlation_id')) {
+                parser.nextToken();
+                expectedCorrelationID = parser.getText();
+                System.assertEquals(expectedCorrelationID, 
+                                    PokitDokMockResponseGenerator.CORRELATION_ID);
+            }
+        }        
+    }
+}

--- a/test/PokitDokMockResponseGenerator.apxc
+++ b/test/PokitDokMockResponseGenerator.apxc
@@ -18,19 +18,23 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
     public final static String ACTIVITY_ID = '11111111';
     public final static String CORRELATION_ID = '99999999';
     public final static String UNSUCCESSFUL_MESSAGE = 'Unprocessable Entity';
+    public final static String SESSION_EXPIRED_MESSAGE = 'Unauthorized';
     
     // Configures whether or not to handle error conditions
-    public boolean isExceptionThrown = false;
-    public boolean isResponseUnsuccessful = false;
+    public Boolean isExceptionThrown = false;
+    public Boolean isResponseUnsuccessful = false;
+    public Boolean hasSessionExpired = false;
     
     /**
      * The constructor allows the calling test code to configure the mock response
      * generator to handle error conditions.
      */
-    public PokitDokMockResponseGenerator(boolean isExceptionThrown, 
-                                         boolean isResponseUnsuccessful) {
-        isExceptionThrown = isExceptionThrown;
-		isResponseUnsuccessful = isResponseUnsuccessful;
+    public PokitDokMockResponseGenerator(Boolean isExceptionThrown, 
+                                         Boolean isResponseUnsuccessful,
+                                         Boolean hasSessionExpired) {
+        this.isExceptionThrown = isExceptionThrown;
+        this.isResponseUnsuccessful = isResponseUnsuccessful;
+        this.hasSessionExpired = hasSessionExpired;
     }
     
     /**
@@ -47,7 +51,7 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
         if (isExceptionThrown) {
             CalloutException e = (CalloutException)CalloutException.class.newInstance();
             e.setMessage('Mock CalloutException thrown.');
-            throw e;   
+            throw e;
         }
 
         // Create a mocked response for testing an unsuccessful response
@@ -55,6 +59,11 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
             return createUnsuccessfulResponse();   
         }
 
+        // Create a mocked response for testing a session expiring
+        if (hasSessionExpired) {
+            return createSessionExpiredResponse();   
+        }
+        
         // Create a mocked response for testing authentication
         HttpResponse response = new HttpResponse();
         if (request.getEndpoint() == PokitDokAPIClient.POKITDOK_BASE_URL + 
@@ -67,6 +76,7 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
                                      PokitDokAPIClient.ELIGIBILITY_ENDPOINT) {			
             response = createEligibilityResponse();            
         }
+
         return response;
     }
     
@@ -80,7 +90,7 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
     private HTTPResponse createAuthenticationResponse() {
         // Create a fake authentication response
         HttpResponse response = new HttpResponse();
-		response.setStatusCode(200);
+        response.setStatusCode(200);
         response.setHeader('Content-Type', 'application/json');
 
         Map<String,Object> authenticationResponse = new Map<String,Object>();
@@ -101,7 +111,7 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
     private HTTPResponse createEligibilityResponse() {
         // Create a fake eligibility response
         HttpResponse response = new HttpResponse();
-		response.setStatusCode(200);
+        response.setStatusCode(200);
         response.setHeader('Content-Type', 'application/json');        
         
         Map<String,Object> eligibilityResponse = new Map<String,Object>();
@@ -128,7 +138,7 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
     private HTTPResponse createUnsuccessfulResponse() {
         // Create a fake unsuccessful authentication response
         HttpResponse response = new HttpResponse();
-		response.setStatusCode(422);
+        response.setStatusCode(422);
         response.setHeader('Content-Type', 'application/json');
 
         Map<String,Object> authenticationResponse = new Map<String,Object>();
@@ -137,4 +147,25 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
         
         return response;
     }
+    
+    /**
+     * The createSessionExpiredResponse method creates a mocked HTTPResponse to an 
+     * API endpoint.  It returns a status code of 401, however, that lets the calling
+     * code know that the session has expired and the token needs to be renewed.
+     * 
+     * @return the HTTPResponse with a 401 status code
+     */
+    private HTTPResponse createSessionExpiredResponse() {
+        // Create a fake unsuccessful authentication response
+        HttpResponse response = new HttpResponse();
+        response.setStatusCode(401);
+        response.setHeader('Content-Type', 'application/json');
+
+        Map<String,Object> apiResponse = new Map<String,Object>();
+        apiResponse.put('errors', SESSION_EXPIRED_MESSAGE);       
+        response.setBody(JSON.serialize(apiResponse));
+        
+        return response;
+    }    
 }
+

--- a/test/PokitDokMockResponseGenerator.apxc
+++ b/test/PokitDokMockResponseGenerator.apxc
@@ -1,0 +1,87 @@
+/**
+ * APEX test classes are not permitted to access remote sites, so all tests of the API
+ * calls need to be mocked.  The PokitDokMockResponseGenerator class implements the 
+ * HttpCalloutMock interface and generate fake HTTPResponses for the various endpoints
+ * of the PokitDok Platform.
+ */
+@isTest
+public class PokitDokMockResponseGenerator implements HttpCalloutMock {
+    // Test constants
+    public final static String ACCESS_TOKEN = 'POKIT_TOKEN';
+    public final static String ACTIVITY_ID = '11111111';
+    public final static String CORRELATION_ID = '99999999';
+    
+    /**
+     * The respond method returns a mocked HTTPResponse that can be tested by assertion.
+     * The following endpoints are mocked:
+     *   - authentication
+     *   - eligibility
+     * 
+     * @param the request is the mocked up request that would be sent to the APIs
+     * @return a mocked HTTPResponse
+     */
+    public HTTPResponse respond(HTTPRequest request) {
+        HttpResponse response = new HttpResponse();
+        
+        // Create a mocked response for testing authentication
+        if (request.getEndpoint() == PokitDokAPIClient.POKITDOK_BASE_URL + 
+            						 PokitDokAPIClient.AUTHENTICATION_ENDPOINT) {
+			response = createAuthenticationResponse();
+        }
+        
+        // Create a mocked response for testing an eligibility request
+        if (request.getEndpoint() == PokitDokAPIClient.POKITDOK_BASE_URL + 
+            						 PokitDokAPIClient.ELIGIBILITY_ENDPOINT) {
+			response = createEligibilityResponse();
+        }
+        return response;
+    }
+
+    /**
+     * The createAuthenticationResponse method creates a mocked HTTPResponse to the
+     * authentication endpoint.  Namely it creates a fake OAuth access token to be
+     * passed in future API calls.
+     * 
+     * @return the HTTPResponse with the access token
+     */
+    private HTTPResponse createAuthenticationResponse() {
+        // Create a fake authentication response
+        HttpResponse response = new HttpResponse();
+		response.setStatusCode(200);
+        response.setHeader('Content-Type', 'application/json');
+
+        Map<String,Object> authenticationResponse = new Map<String,Object>();
+        authenticationResponse.put('access_token', ACCESS_TOKEN);       
+        response.setBody(JSON.serialize(authenticationResponse));
+        
+        return response;
+    }
+
+    /**
+     * The createEligibilityResponse method creates a mocked HTTPResponse to the 
+     * eligibility endpoint.  Namely it creates a fake Activity ID and Correlation 
+     * ID in the JSON.  These two pieces of data would be in every response returned
+     * by the PokitDok Platform APIs.
+     * 
+     * @return the HTTPResponse with the Activity ID and Correlation ID
+     */    
+    private HTTPResponse createEligibilityResponse() {
+        // Create a fake eligibility response
+        HttpResponse response = new HttpResponse();
+		response.setStatusCode(200);
+        response.setHeader('Content-Type', 'application/json');        
+        
+        Map<String,Object> eligibilityResponse = new Map<String,Object>();
+        
+		Map<String,Object> meta = new Map<String,Object>();
+        meta.put('activity_id', ACTIVITY_ID);
+        eligibilityResponse.put('meta', meta);
+        
+        Map<String,Object> data = new Map<String,Object>();
+        data.put('correlation_id', CORRELATION_ID);
+        eligibilityResponse.put('data', data);    
+        
+        response.setBody(JSON.serialize(eligibilityResponse));
+        return response;
+    }
+}

--- a/test/PokitDokMockResponseGenerator.apxc
+++ b/test/PokitDokMockResponseGenerator.apxc
@@ -3,13 +3,35 @@
  * calls need to be mocked.  The PokitDokMockResponseGenerator class implements the 
  * HttpCalloutMock interface and generate fake HTTPResponses for the various endpoints
  * of the PokitDok Platform.
+ * 
+ * Copyright (C) 2016, All Rights Reserved, PokitDok, Inc.
+ * https://platform.pokitdok.com
+ *
+ * Please see the License.txt file for more information.
+ * All other rights reserved.
  */
 @isTest
 public class PokitDokMockResponseGenerator implements HttpCalloutMock {
+    
     // Test constants
     public final static String ACCESS_TOKEN = 'POKIT_TOKEN';
     public final static String ACTIVITY_ID = '11111111';
     public final static String CORRELATION_ID = '99999999';
+    public final static String UNSUCCESSFUL_MESSAGE = 'Unprocessable Entity';
+    
+    // Configures whether or not to handle error conditions
+    public boolean isExceptionThrown = false;
+    public boolean isResponseUnsuccessful = false;
+    
+    /**
+     * The constructor allows the calling test code to configure the mock response
+     * generator to handle error conditions.
+     */
+    public PokitDokMockResponseGenerator(boolean isExceptionThrown, 
+                                         boolean isResponseUnsuccessful) {
+        isExceptionThrown = isExceptionThrown;
+		isResponseUnsuccessful = isResponseUnsuccessful;
+    }
     
     /**
      * The respond method returns a mocked HTTPResponse that can be tested by assertion.
@@ -21,22 +43,33 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
      * @return a mocked HTTPResponse
      */
     public HTTPResponse respond(HTTPRequest request) {
-        HttpResponse response = new HttpResponse();
+        // Throw an exception for testing an HTTP error
+        if (isExceptionThrown) {
+            CalloutException e = (CalloutException)CalloutException.class.newInstance();
+            e.setMessage('Mock CalloutException thrown.');
+            throw e;   
+        }
+        
+        // Create a mocked response for testing an unsuccessful response
+        if (isResponseUnsuccessful) {
+            return createUnsuccessfulResponse();   
+        }
         
         // Create a mocked response for testing authentication
+        HttpResponse response = new HttpResponse();
         if (request.getEndpoint() == PokitDokAPIClient.POKITDOK_BASE_URL + 
-            						 PokitDokAPIClient.AUTHENTICATION_ENDPOINT) {
-			response = createAuthenticationResponse();
+                                     PokitDokAPIClient.AUTHENTICATION_ENDPOINT) {                                         
+            response = createAuthenticationResponse();
         }
         
         // Create a mocked response for testing an eligibility request
         if (request.getEndpoint() == PokitDokAPIClient.POKITDOK_BASE_URL + 
-            						 PokitDokAPIClient.ELIGIBILITY_ENDPOINT) {
-			response = createEligibilityResponse();
+                                     PokitDokAPIClient.ELIGIBILITY_ENDPOINT) {			
+            response = createEligibilityResponse();            
         }
         return response;
     }
-
+    
     /**
      * The createAuthenticationResponse method creates a mocked HTTPResponse to the
      * authentication endpoint.  Namely it creates a fake OAuth access token to be
@@ -73,7 +106,7 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
         
         Map<String,Object> eligibilityResponse = new Map<String,Object>();
         
-		Map<String,Object> meta = new Map<String,Object>();
+        Map<String,Object> meta = new Map<String,Object>();
         meta.put('activity_id', ACTIVITY_ID);
         eligibilityResponse.put('meta', meta);
         
@@ -82,6 +115,26 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
         eligibilityResponse.put('data', data);    
         
         response.setBody(JSON.serialize(eligibilityResponse));
+        return response;
+    }
+
+    /**
+     * The createUnsuccessfulResponse method creates a mocked HTTPResponse to an 
+     * API endpoint.  It returns a status code of 422, however, to exercise a failure
+     * case.
+     * 
+     * @return the HTTPResponse with a 422 status code
+     */
+    private HTTPResponse createUnsuccessfulResponse() {
+        // Create a fake unsuccessful authentication response
+        HttpResponse response = new HttpResponse();
+		response.setStatusCode(422);
+        response.setHeader('Content-Type', 'application/json');
+
+        Map<String,Object> authenticationResponse = new Map<String,Object>();
+        authenticationResponse.put('errors', UNSUCCESSFUL_MESSAGE);       
+        response.setBody(JSON.serialize(authenticationResponse));
+        
         return response;
     }
 }

--- a/test/PokitDokMockResponseGenerator.apxc
+++ b/test/PokitDokMockResponseGenerator.apxc
@@ -49,12 +49,12 @@ public class PokitDokMockResponseGenerator implements HttpCalloutMock {
             e.setMessage('Mock CalloutException thrown.');
             throw e;   
         }
-        
+
         // Create a mocked response for testing an unsuccessful response
         if (isResponseUnsuccessful) {
             return createUnsuccessfulResponse();   
         }
-        
+
         // Create a mocked response for testing authentication
         HttpResponse response = new HttpResponse();
         if (request.getEndpoint() == PokitDokAPIClient.POKITDOK_BASE_URL + 

--- a/test/PokitDokSessionCacheManagerTest.apxc
+++ b/test/PokitDokSessionCacheManagerTest.apxc
@@ -1,0 +1,83 @@
+/**
+ * The PokitDokSessionCacheManagerTest class tests out the functionality of managing
+ * the OAuth access token for session management with the PokitDok Platform.
+ * 
+ * Copyright (C) 2016, All Rights Reserved, PokitDok, Inc.
+ * https://platform.pokitdok.com
+ *
+ * Please see the License.txt file for more information.
+ * All other rights reserved.
+ */
+@isTest
+public class PokitDokSessionCacheManagerTest {
+    
+    public final static String TEST_TOKEN = 'TEST_TOKEN';
+    public final static String TEST_CLIENT_ID = 'ClientID';
+    
+    /**
+     * The testCacheEnabled method tests that the organization cache is available for 
+     * usage.
+     */
+    @isTest 
+    static void testCacheAvailable() {
+        // Verify the cache partition is available
+        PokitDokSessionCacheManager sessionManager = new PokitDokSessionCacheManager(TEST_CLIENT_ID);
+        System.assert(sessionManager.cacheEnabled);
+
+        Map<String, Object> cacheStatistics = sessionManager.getCacheStatistics();        
+        String default_partition = (String) cacheStatistics.get('default_partition');        
+        System.assertNotEquals('', default_partition);
+    }
+
+    /**
+     * The testStorage method tests that the storage, retrieval and removal of session
+     * access tokens work.
+     */
+    @isTest 
+    static void testProperStorage() {
+        // Put, get, remove, rinse, repeat
+        PokitDokSessionCacheManager sessionManager = new PokitDokSessionCacheManager(TEST_CLIENT_ID);
+        sessionManager.putToken(TEST_TOKEN);
+		
+        String retrievedToken = sessionManager.getToken();
+        System.assertEquals(TEST_TOKEN, retrievedToken);
+       
+        Boolean removedToken = sessionManager.removeToken();
+        System.assertEquals(true, removedToken);
+    }
+    
+    /**
+     * The testCacheMiss method tests that retrieval fails when trying to access a token for
+     * a completely different client app.
+     */
+    @isTest 
+    static void testCacheMiss() {
+        // Register the cache manager with the normal Client ID and add the token to it
+        PokitDokSessionCacheManager sessionManager = new PokitDokSessionCacheManager(TEST_CLIENT_ID);
+        sessionManager.putToken(TEST_TOKEN);
+        
+        // Try to retrieve it from a cache manager registered with a different Client ID
+        sessionManager = new PokitDokSessionCacheManager(TEST_CLIENT_ID + 'xxx');
+        String retrievedToken = sessionManager.getToken();
+        System.assertEquals(null, retrievedToken);
+    }
+    
+    /**
+    * The testCacheDisabled method tests that the organization cache is not available, the 
+    * cache storage methods aren't available.
+    */
+    @isTest 
+    static void testCacheUnavailable() {
+        // Fake unavailability by manually turning off the cacheEnabled flag
+        PokitDokSessionCacheManager sessionManager = new PokitDokSessionCacheManager(TEST_CLIENT_ID);
+        sessionManager.cacheEnabled = false;
+        sessionManager.putToken(TEST_TOKEN);
+		
+        String retrievedToken = sessionManager.getToken();
+        System.assertEquals(null, retrievedToken);
+
+        Boolean removedToken = sessionManager.removeToken();
+        System.assertEquals(false, removedToken);
+    }
+}
+


### PR DESCRIPTION
**Updated reference implementation to read/write data from/to the Patient record.**
The reference implementation was hard coding the values sent to the eligibility request. Updated it to use the Patient ID from the record in question to look up the values to send to the API and write the response values to the record.


**Implemented caching of the session access token**
This works by utilizing the Salesforce Platform Cache.  There are two types of caches: Session and Org.  I employ the Org cache so that different folks with different sessions can all use the same access token (since it is based on a singular Client ID.)  If a particular has different PokitDok Platform Apps, each with their own Client ID, the tokens will be stored separately.

These [docs](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_cache_namespace_overview.htm) provide a detailed look at how Salesforce Platform Cache works and how it is configured.

The API Client follows the standard pattern of authentication.  It first looks in the cache for a token and uses it if it is available.  If the request returns a 401, the cache is flushed, the App is reauthenticated with the new token cached and the original API request is replayed.

To facilitate token cache management a new PokitDokSessionCacheManager was created.  This has high level functions to get/put/remove tokens and also abstracts the verification that the Salesforce Platform Cache is set up and there is a default Cache Partition.

The tests have all been updated to test out the new functionality.  The documentation and reference implementation have also been updated as well.